### PR TITLE
A+ Studio: image lifecycle, cost controls, OpenAI support, and design polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ apps/web/certificates/*.pem
 
 # Local scratch screenshots
 sellavant-home-smoke.png
+
+# A+ design-preview renders (dev harness output)
+tools/render-out/

--- a/apps/web/src/app/(dashboard)/a-plus/aplus-editor.tsx
+++ b/apps/web/src/app/(dashboard)/a-plus/aplus-editor.tsx
@@ -22,6 +22,7 @@ import {
   Monitor,
   PackageCheck,
   Plus,
+  RefreshCw,
   ShieldAlert,
   Smartphone,
   Sparkles,
@@ -1690,6 +1691,7 @@ export function APlusEditor({
   const [brandFontNotes, setBrandFontNotes] = useState('');
   const [brandLogoAssetId, setBrandLogoAssetId] = useState('');
   const [rawNotes, setRawNotes] = useState('');
+  const [rebuildingNotes, setRebuildingNotes] = useState(false);
   const [assetLibrary, setAssetLibrary] = useState<AssetLibraryItem[]>([]);
   const [draftId, setDraftId] = useState<string | null>(null);
   const [draftName, setDraftName] = useState('Untitled A+ draft');
@@ -2557,6 +2559,27 @@ export function APlusEditor({
   function inspectSource(source: SourceLink) {
     void checkSource(source);
     void extractSource(source);
+  }
+
+  /**
+   * Clear "What you know so far" and re-extract every linked source into it.
+   * Needed because the notes builder only appends/dedupes by header — it never
+   * rewrites old blocks — so re-extracting in place can't drop stale lines
+   * (e.g. a prior price line or an unlabeled competitor block). Clearing first
+   * lets each source re-append under the current rules (price filtered out,
+   * non-product sources labeled). Structured fields you already filled are left
+   * alone: mergeSourceFacts only fills blanks.
+   */
+  async function rebuildFromSources() {
+    const linked = sources.filter((source) => source.url.trim());
+    if (!linked.length || rebuildingNotes) return;
+    setRebuildingNotes(true);
+    try {
+      setRawNotes('');
+      await Promise.all(linked.map((source) => extractSource(source)));
+    } finally {
+      setRebuildingNotes(false);
+    }
   }
 
   function addDroppedSource(url: string) {
@@ -3599,7 +3622,26 @@ export function APlusEditor({
           </p>
         </div>
         <div className="space-y-2">
-          <Label htmlFor="notes">What you know so far</Label>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <Label htmlFor="notes">What you know so far</Label>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => void rebuildFromSources()}
+              disabled={
+                rebuildingNotes || !sources.some((source) => source.url.trim())
+              }
+              title="Clear these notes and re-read every linked source with the current extraction rules"
+            >
+              {rebuildingNotes ? (
+                <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="mr-2 h-3.5 w-3.5" />
+              )}
+              Rebuild from sources
+            </Button>
+          </div>
           <Textarea
             id="notes"
             value={rawNotes}

--- a/apps/web/src/app/(dashboard)/a-plus/aplus-editor.tsx
+++ b/apps/web/src/app/(dashboard)/a-plus/aplus-editor.tsx
@@ -163,6 +163,14 @@ function isGeneratedLibraryAsset(item: AssetLibraryItem): boolean {
   return name.startsWith('generated-');
 }
 
+// Some drags/OSes hand over files with an empty or non-image MIME type, so we
+// also accept by extension — otherwise those images are silently dropped.
+const IMAGE_FILE_EXT_RE =
+  /\.(png|jpe?g|webp|avif|gif|heic|heif|bmp|tiff?|svg)$/i;
+function isImageFile(file: File): boolean {
+  return file.type.startsWith('image/') || IMAGE_FILE_EXT_RE.test(file.name);
+}
+
 type APlusModule = {
   id: string;
   tier: ContentTier;
@@ -2175,7 +2183,9 @@ export function APlusEditor({
   }
 
   async function uploadLibraryAsset(file: File) {
-    const itemId = `${Date.now()}-${file.name}`;
+    // Unique per item — a batch drop runs in one tick, so Date.now() collides
+    // and same-named files would share a React key (and collapse to one row).
+    const itemId = crypto.randomUUID();
     setAssetLibrary((current) => [
       ...current,
       {
@@ -2307,7 +2317,7 @@ export function APlusEditor({
 
   function uploadLibraryFiles(fileList: FileList | File[]) {
     [...fileList]
-      .filter((file) => file.type.startsWith('image/'))
+      .filter(isImageFile)
       .forEach((file) => void uploadLibraryAsset(file));
   }
 

--- a/apps/web/src/app/(dashboard)/a-plus/aplus-editor.tsx
+++ b/apps/web/src/app/(dashboard)/a-plus/aplus-editor.tsx
@@ -152,6 +152,16 @@ type AssetLibraryItem = {
   uploadErrorCode?: string;
 };
 
+/**
+ * AI-generated A+ images are named `generated-*` and belong in module slots,
+ * not the user uploads library. Older drafts may still have them persisted in
+ * `assets`, so we filter them out on load.
+ */
+function isGeneratedLibraryAsset(item: AssetLibraryItem): boolean {
+  const name = item.asset?.originalFileName ?? item.fileName ?? '';
+  return name.startsWith('generated-');
+}
+
 type APlusModule = {
   id: string;
   tier: ContentTier;
@@ -169,6 +179,9 @@ type PackageImageJob = {
   jobId: string;
   prompt: string;
   size: string;
+  /** True when this slot already has a generated/uploaded image (e.g. a draft
+   * reloaded from storage) — so "Generate all" never re-pays for it. */
+  hasImage: boolean;
 };
 
 type ImageJobResult =
@@ -1732,6 +1745,14 @@ export function APlusEditor({
   const [imageJobResults, setImageJobResults] = useState<
     Record<string, ImageJobResult>
   >({});
+  // Draft mode generates cheap low-quality images for fast iteration; turn off
+  // for full-quality finals. (Only the gpt-image-1 backend honors quality.)
+  const [draftImages, setDraftImages] = useState(false);
+  // Full-resolution image opened from a library thumbnail (null = closed).
+  const [previewImage, setPreviewImage] = useState<{
+    assetId: string;
+    fileName: string;
+  } | null>(null);
   const [loadedFonts, setLoadedFonts] = useState<Record<string, boolean>>({});
   const selectedBrandGuide =
     brandGuides.find((guide) => guide.brandGuideId === brandGuideId) || null;
@@ -2613,6 +2634,9 @@ export function APlusEditor({
         body: JSON.stringify({
           prompt: prepareGeneratedImagePrompt(prompt, imageForbiddenText),
           size,
+          // Draft mode generates cheap, low-quality images for fast iteration;
+          // finals are full quality. Only gpt-image-1 honors this.
+          quality: draftImages ? 'low' : undefined,
         }),
       });
       const body = (await response.json()) as {
@@ -2654,33 +2678,11 @@ export function APlusEditor({
       // persisted with the design (and survives a reload), not just held in
       // transient imageJobResults. jobId is "img-{order}-{role}".
       writeSlotImageIntoPackage(jobId, imageUrl);
-      const generatedAsset = body.asset;
-      if (generatedAsset) {
-        const newItem: AssetLibraryItem = {
-          id: generatedAsset.assetId,
-          fileName: generatedAsset.originalFileName,
-          description: `Generated for image brief ${jobId}`,
-          asset: {
-            assetId: generatedAsset.assetId,
-            createdForFeature: 'a-plus',
-            originalFileName: generatedAsset.originalFileName,
-            mimeType: generatedAsset.mimeType,
-            sizeBytes: generatedAsset.sizeBytes,
-            hashes: { sha256: '' },
-            status: generatedAsset.status,
-            storage: generatedAsset.storage,
-          },
-          uploadStatus:
-            generatedAsset.status === 'duplicate' ? 'duplicate' : 'uploaded',
-        };
-        setAssetLibrary((current) =>
-          current.some(
-            (entry) => entry.asset?.assetId === generatedAsset.assetId
-          )
-            ? current
-            : [...current, newItem]
-        );
-      }
+      // Generated images live ONLY in the package slot (written above) — they
+      // are intentionally not added to the uploads asset library, which is for
+      // user-provided source images. Keeping generated outputs out of the
+      // library also lets save-time cleanup reclaim a refreshed slot's prior
+      // image once the slot stops referencing it (see a-plus-asset-cleanup).
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Image generation failed.';
@@ -2699,11 +2701,13 @@ export function APlusEditor({
         jobId: slotJobId(module.order, slot.role),
         prompt: slot.brief,
         size: slot.size,
+        hasImage: Boolean(slot.image?.url),
       }))
     );
   }, [generatedPackage]);
 
   const hasRunnablePackageImageJobs = allPackageImageJobs.some((job) => {
+    if (job.hasImage) return false;
     const status = imageJobResults[job.jobId]?.status;
     return status !== 'done' && status !== 'generating';
   });
@@ -2714,6 +2718,9 @@ export function APlusEditor({
 
   function generateAllPackageImages() {
     for (const job of allPackageImageJobs) {
+      // Never re-pay for a slot that already has an image — including a draft
+      // reloaded from storage, where in-memory job status is empty.
+      if (job.hasImage) continue;
       const status = imageJobResults[job.jobId]?.status;
       if (status === 'done' || status === 'generating') continue;
       void generateImageForJob(job.jobId, job.prompt, job.size);
@@ -2892,7 +2899,10 @@ export function APlusEditor({
     if (payload.brandLogoAssetId !== undefined)
       setBrandLogoAssetId(payload.brandLogoAssetId);
     if (payload.rawNotes !== undefined) setRawNotes(payload.rawNotes);
-    if (payload.assets?.length) setAssetLibrary(payload.assets);
+    if (payload.assets?.length)
+      setAssetLibrary(
+        payload.assets.filter((a) => !isGeneratedLibraryAsset(a))
+      );
     if (payload.strategyId) setStrategyId(payload.strategyId);
     if (payload.sources?.length) setSources(payload.sources);
     if (payload.modules?.length) setModules(payload.modules);
@@ -4008,6 +4018,28 @@ export function APlusEditor({
                 className="grid gap-3 rounded-md border bg-background p-3 md:grid-cols-[minmax(0,220px)_1fr_auto]"
               >
                 <div className="min-w-0">
+                  {item.asset?.assetId &&
+                  (item.uploadStatus === 'uploaded' ||
+                    item.uploadStatus === 'duplicate') ? (
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setPreviewImage({
+                          assetId: item.asset!.assetId,
+                          fileName: item.fileName,
+                        })
+                      }
+                      className="mb-2 block w-full overflow-hidden rounded border bg-muted transition hover:opacity-90"
+                      aria-label={`Preview ${item.fileName}`}
+                    >
+                      <img
+                        src={`/api/a-plus/assets/${item.asset.assetId}?w=320`}
+                        alt={item.fileName}
+                        loading="lazy"
+                        className="h-28 w-full object-cover"
+                      />
+                    </button>
+                  ) : null}
                   <div className="flex items-center gap-2">
                     {item.uploadStatus === 'hashing' ||
                     item.uploadStatus === 'uploading' ? (
@@ -4163,24 +4195,38 @@ export function APlusEditor({
             Generated A+ Package
           </CardTitle>
           {allPackageImageJobs.length ? (
-            <Button
-              type="button"
-              variant="default"
-              size="sm"
-              disabled={!hasRunnablePackageImageJobs}
-              onClick={generateAllPackageImages}
-            >
-              {isGeneratingPackageImage ? (
-                <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <WandSparkles className="mr-2 h-3.5 w-3.5" />
-              )}
-              {isGeneratingPackageImage
-                ? 'Generating images'
-                : hasRunnablePackageImageJobs
-                ? 'Generate all images'
-                : 'All images generated'}
-            </Button>
+            <div className="flex items-center gap-3">
+              <label
+                className="flex cursor-pointer items-center gap-1.5 text-xs text-muted-foreground"
+                title="Generate cheaper, low-quality draft images for fast iteration. Turn off for full-quality finals."
+              >
+                <input
+                  type="checkbox"
+                  className="h-3.5 w-3.5"
+                  checked={draftImages}
+                  onChange={(event) => setDraftImages(event.target.checked)}
+                />
+                Draft quality
+              </label>
+              <Button
+                type="button"
+                variant="default"
+                size="sm"
+                disabled={!hasRunnablePackageImageJobs}
+                onClick={generateAllPackageImages}
+              >
+                {isGeneratingPackageImage ? (
+                  <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <WandSparkles className="mr-2 h-3.5 w-3.5" />
+                )}
+                {isGeneratingPackageImage
+                  ? 'Generating images'
+                  : hasRunnablePackageImageJobs
+                  ? 'Generate all images'
+                  : 'All images generated'}
+              </Button>
+            </div>
           ) : null}
         </div>
       </CardHeader>
@@ -5026,6 +5072,37 @@ export function APlusEditor({
           </div>
         </div>
       )}
+
+      {previewImage ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+          role="dialog"
+          aria-modal="true"
+          onClick={() => setPreviewImage(null)}
+        >
+          <div
+            className="relative max-h-full max-w-4xl"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <img
+              src={`/api/a-plus/assets/${previewImage.assetId}`}
+              alt={previewImage.fileName}
+              className="max-h-[85vh] w-auto rounded-md object-contain shadow-2xl"
+            />
+            <div className="mt-2 flex items-center justify-between gap-3 text-sm text-white">
+              <span className="truncate">{previewImage.fileName}</span>
+              <Button
+                type="button"
+                size="sm"
+                variant="secondary"
+                onClick={() => setPreviewImage(null)}
+              >
+                Close
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/a-plus/aplus-editor.tsx
+++ b/apps/web/src/app/(dashboard)/a-plus/aplus-editor.tsx
@@ -2416,9 +2416,8 @@ export function APlusEditor({
     if ((!productOneLiner.trim() || overwrite) && facts.oneLiner) {
       setProductOneLiner(facts.oneLiner);
     }
-    if ((!pricePoint.trim() || overwrite) && facts.pricePoint) {
-      setPricePoint(facts.pricePoint);
-    }
+    // A+ content never shows price, and auto-extracted prices are frequently
+    // wrong, so we deliberately do NOT pull price into the brief.
     if ((!keyFeatures.trim() || overwrite) && facts.features.length) {
       setKeyFeatures(facts.features.join('\n'));
     }
@@ -2429,22 +2428,25 @@ export function APlusEditor({
       setDifferentiators(facts.differentiators.join('\n'));
     }
 
-    const evidence = facts.evidence.length
+    const baseEvidence = facts.evidence.length
       ? facts.evidence
       : ([
           facts.productName ? `Product: ${facts.productName}` : null,
           facts.oneLiner ? `Summary: ${facts.oneLiner}` : null,
           ...facts.features.map((feature) => `Feature: ${feature}`),
         ].filter(Boolean) as string[]);
+    // A+ never uses price — keep it out of the notes the AI reads.
+    const evidence = baseEvidence.filter((line) => !/^\s*price\b/i.test(line));
 
     const displayUrl = facts.finalUrl || source.url;
-    setRawNotes((current) =>
-      appendUniqueText(
-        current,
-        `Source facts from ${source.kind}: ${displayUrl}`,
-        evidence
-      )
-    );
+    // Only the Product listing describes OUR product. Mark every other source
+    // as a different product so the AI never copies a competitor's attributes
+    // (color, size, materials, pack count) into our copy or image briefs.
+    const sourceHeader =
+      source.kind === 'Product listing'
+        ? `Source facts from ${source.kind}: ${displayUrl}`
+        : `Source facts from ${source.kind} — DIFFERENT product, for comparison/positioning ONLY (do NOT describe our product with these): ${displayUrl}`;
+    setRawNotes((current) => appendUniqueText(current, sourceHeader, evidence));
   }
 
   function sourceOverwriteCandidateCount(

--- a/apps/web/src/app/(dashboard)/a-plus/components/a-plus-design.tsx
+++ b/apps/web/src/app/(dashboard)/a-plus/components/a-plus-design.tsx
@@ -6,6 +6,7 @@ import {
   applyAPlusGuardrails,
   type APlusGeneratedModule,
   type APlusImageSlot,
+  type IconRowIcon,
 } from '@farvisionllc/models';
 
 /**
@@ -53,6 +54,10 @@ export type BrandTheme = {
   bodyFont: string;
   brandName?: string;
   logoUrl?: string;
+  /** Logo width/height ratio, so the logo plate hugs the mark (no big margins). */
+  logoAspect?: number;
+  /** Brand-header treatment when an ambient backdrop is present. */
+  heroVariant?: 'plate' | 'glass' | 'split' | 'overlay';
   // --- style treatments (consumed by the shared primitives) ---
   style: DesignStyleKey;
   headingWeight: number;
@@ -568,22 +573,26 @@ function Bullets({ items, theme }: { items: string[]; theme: BrandTheme }) {
 
 /** Bold spec/size pill (e.g. "16 OZ") overlaid on a hero image. */
 function SpecBadge({ text, theme }: { text: string; theme: BrandTheme }) {
+  // A branded "tag": accent fill, a fine inner ring, and tracked uppercase type
+  // for a premium product-badge feel (vs a plain white pill).
   return (
     <div
       style={{
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        background: '#FFFFFF',
-        color: '#111111',
+        background: theme.accent,
+        color: theme.accentInk,
         fontFamily: theme.headingFont,
         fontWeight: 800,
-        fontSize: 24,
-        letterSpacing: 0.5,
+        fontSize: 18,
+        letterSpacing: 1.5,
+        textTransform: 'uppercase',
         lineHeight: 1,
-        padding: '10px 18px',
+        padding: '10px 16px',
         borderRadius: theme.radius,
-        boxShadow: '0 6px 18px rgba(0,0,0,0.22)',
+        border: `1.5px solid ${withAlpha('#FFFFFF', 0.55)}`,
+        boxShadow: '0 8px 20px rgba(0,0,0,0.3)',
       }}
     >
       {text.toUpperCase()}
@@ -917,15 +926,6 @@ function DesignedOverlayHero({
             textAlign,
           }}
         >
-          <div
-            style={{
-              width: 52,
-              height: 4,
-              marginBottom: 20,
-              borderRadius: 4,
-              background: theme.accent,
-            }}
-          />
           {headline ? (
             <div
               style={{
@@ -1032,8 +1032,14 @@ function DesignedColumns({
               border: carded ? `1px solid ${theme.line}` : 'none',
             }}
           >
+            {!mobile && carded ? (
+              <div
+                style={{ display: 'flex', height: 4, background: theme.accent }}
+              />
+            ) : null}
             <div
               style={{
+                position: 'relative',
                 display: 'flex',
                 width: mobile ? 140 : '100%',
                 borderRadius: carded ? 0 : theme.radius,
@@ -1041,6 +1047,28 @@ function DesignedColumns({
               }}
             >
               <Photo slot={cell.image} height={mobile ? 120 : imgH} />
+              {/* Bold numbered step badge over the image. */}
+              <div
+                style={{
+                  position: 'absolute',
+                  top: 10,
+                  left: 10,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: mobile ? 28 : 34,
+                  height: mobile ? 28 : 34,
+                  borderRadius: 34,
+                  background: theme.accent,
+                  color: theme.accentInk,
+                  fontFamily: theme.headingFont,
+                  fontSize: mobile ? 14 : 16,
+                  fontWeight: 800,
+                  boxShadow: '0 4px 12px rgba(0,0,0,0.22)',
+                }}
+              >
+                {String(i + 1).padStart(2, '0')}
+              </div>
             </div>
             <div
               style={{
@@ -1056,11 +1084,11 @@ function DesignedColumns({
                 <div
                   style={{
                     fontFamily: theme.headingFont,
-                    fontSize: mobile ? 18 : 17,
+                    fontSize: mobile ? 18 : 19,
                     fontWeight: theme.headingWeight,
                     color: theme.ink,
                     letterSpacing: theme.headingTracking,
-                    marginBottom: 6,
+                    marginBottom: 7,
                   }}
                 >
                   {clean(cell.headline)}
@@ -1086,6 +1114,116 @@ function DesignedColumns({
   );
 }
 
+const COMPARISON_POSITIVE =
+  /^(yes|included|✓|true|standard|always|full|both)\b/i;
+const COMPARISON_NEGATIVE = /^(no|none|n\/a|n\.a\.|false|✗|never)\b/i;
+
+/** Classify a comparison cell so we can swap text for a check/cross glyph. */
+function comparisonGlyph(value: string): 'yes' | 'no' | null {
+  const v = value.trim();
+  if (!v) return null;
+  if (v === '✓' || COMPARISON_POSITIVE.test(v)) return 'yes';
+  if (
+    v === '✗' ||
+    v === '—' ||
+    v === '–' ||
+    v === '-' ||
+    COMPARISON_NEGATIVE.test(v)
+  )
+    return 'no';
+  return null;
+}
+
+/**
+ * Small accent check / muted cross used in comparison cells. The glyphs are
+ * DRAWN (rotated borders/bars), not typed — the bundled satori font has no
+ * ✓/✗, so a unicode character would render as tofu in PNG export.
+ */
+function GlyphBadge({
+  kind,
+  theme,
+}: {
+  kind: 'yes' | 'no';
+  theme: BrandTheme;
+}) {
+  const yes = kind === 'yes';
+  const mark = yes ? theme.accentInk : theme.muted;
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: 22,
+        height: 22,
+        borderRadius: 22,
+        background: yes ? theme.accent : 'transparent',
+        border: yes ? 'none' : `1.5px solid ${withAlpha(theme.muted, 0.4)}`,
+      }}
+    >
+      {yes ? (
+        <div
+          style={{
+            display: 'flex',
+            width: 10,
+            height: 5,
+            marginTop: -2,
+            borderLeft: `2.5px solid ${mark}`,
+            borderBottom: `2.5px solid ${mark}`,
+            transform: 'rotate(-45deg)',
+          }}
+        />
+      ) : (
+        // A muted dash for "no" — satori's rotate-origin handling makes a clean
+        // X unreliable, and check-vs-dash reads clearly in a comparison table.
+        <div
+          style={{
+            display: 'flex',
+            width: 9,
+            height: 2,
+            borderRadius: 2,
+            background: mark,
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+/** Accent "VS" medallion shown between the two cards of a head-to-head table. */
+function VsBadge({ theme }: { theme: BrandTheme }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        alignSelf: 'center',
+        margin: '0 2px',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 52,
+          height: 52,
+          borderRadius: 52,
+          background: theme.accent,
+          color: theme.accentInk,
+          fontFamily: theme.headingFont,
+          fontSize: 19,
+          fontWeight: 800,
+          letterSpacing: 0.5,
+          boxShadow: '0 8px 20px rgba(0,0,0,0.25)',
+        }}
+      >
+        VS
+      </div>
+    </div>
+  );
+}
+
 function DesignedComparison({
   module,
   ctx,
@@ -1093,7 +1231,8 @@ function DesignedComparison({
   module: Extract<APlusGeneratedModule, { type: 'comparison-table' }>;
   ctx: Ctx;
 }) {
-  const { theme } = ctx;
+  const { theme, mobile } = ctx;
+  const ribbonH = 26;
   return (
     <div
       style={{
@@ -1101,92 +1240,148 @@ function DesignedComparison({
         flexDirection: 'column',
         width: '100%',
         background: theme.bg,
-        paddingBottom: 30,
+        paddingBottom: 34,
       }}
     >
       <SectionTitle title={module.title} theme={theme} />
       <div
         style={{
           display: 'flex',
-          flexDirection: ctx.mobile ? 'column' : 'row',
-          padding: ctx.mobile ? '10px 22px 0' : '14px 30px 0',
+          flexDirection: mobile ? 'column' : 'row',
+          alignItems: mobile ? 'stretch' : 'flex-start',
+          padding: mobile ? '12px 22px 0' : '18px 30px 0',
         }}
       >
-        {module.products.map((product, pi) => (
-          <div
-            key={pi}
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              flex: ctx.mobile ? '0 1 auto' : 1,
-              width: ctx.mobile ? '100%' : 'auto',
-              margin: ctx.mobile
-                ? '0 0 10px 0'
-                : pi === 0
-                ? '0 8px 0 0'
-                : pi === module.products.length - 1
-                ? '0 0 0 8px'
-                : '0 8px',
-              background: product.highlight ? theme.surface : '#F0EAE1',
-              border: `1px solid ${
-                product.highlight ? theme.accent : theme.line
-              }`,
-              borderRadius: theme.radius,
-              padding: 18,
-            }}
-          >
+        {module.products.flatMap((product, pi) => {
+          const highlight = !!product.highlight;
+          const card = (
             <div
+              key={pi}
               style={{
-                fontFamily: theme.headingFont,
-                fontSize: 18,
-                fontWeight: 700,
-                color: theme.ink,
-                textAlign: 'center',
-                marginBottom: 12,
+                display: 'flex',
+                flexDirection: 'column',
+                flex: mobile ? '0 1 auto' : 1,
+                width: mobile ? '100%' : 'auto',
+                margin: mobile
+                  ? '0 0 12px 0'
+                  : pi === 0
+                  ? '0 7px 0 0'
+                  : pi === module.products.length - 1
+                  ? '0 0 0 7px'
+                  : '0 7px',
+                background: highlight ? theme.surface : theme.surfaceAlt,
+                border: `${highlight ? 2 : 1}px solid ${
+                  highlight ? theme.accent : theme.line
+                }`,
+                borderRadius: theme.radius * 1.4,
+                overflow: 'hidden',
+                boxShadow: highlight ? '0 16px 40px rgba(0,0,0,0.12)' : 'none',
               }}
             >
-              {clean(product.title)}
-            </div>
-            <div style={{ display: 'flex', flexDirection: 'column' }}>
-              {module.rows.map((row, ri) => {
-                const value = clean(row.values[pi] ?? '');
-                return (
-                  <div
-                    key={ri}
-                    style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      padding: '7px 0',
-                      borderTop: ri === 0 ? 'none' : `1px solid ${theme.line}`,
-                    }}
-                  >
+              {/* Ribbon — reserved on every card so headers stay aligned. */}
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  height: ribbonH,
+                  background: highlight ? theme.accent : 'transparent',
+                  color: highlight ? theme.accentInk : 'transparent',
+                  fontFamily: theme.bodyFont,
+                  fontSize: 11,
+                  fontWeight: 800,
+                  letterSpacing: 1.5,
+                }}
+              >
+                {highlight ? 'RECOMMENDED' : ''}
+              </div>
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  padding: '13px 14px',
+                  background: highlight
+                    ? withAlpha(theme.accent, 0.12)
+                    : 'transparent',
+                  fontFamily: theme.headingFont,
+                  fontSize: 17,
+                  fontWeight: 800,
+                  color: theme.ink,
+                  textAlign: 'center',
+                }}
+              >
+                {clean(product.title)}
+              </div>
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  padding: '4px 16px 16px',
+                }}
+              >
+                {module.rows.map((row, ri) => {
+                  const value = clean(row.values[pi] ?? '');
+                  const glyph = comparisonGlyph(value);
+                  return (
                     <div
+                      key={ri}
                       style={{
-                        flex: 1,
-                        fontFamily: theme.bodyFont,
-                        fontSize: 12,
-                        color: theme.muted,
+                        display: 'flex',
+                        alignItems: 'center',
+                        padding: '10px 0',
+                        borderTop:
+                          ri === 0 ? 'none' : `1px solid ${theme.line}`,
                       }}
                     >
-                      {row.label}
+                      <div
+                        style={{
+                          display: 'flex',
+                          flex: 1,
+                          fontFamily: theme.bodyFont,
+                          fontSize: 12.5,
+                          color: theme.muted,
+                        }}
+                      >
+                        {row.label}
+                      </div>
+                      <div
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'flex-end',
+                          minWidth: 24,
+                        }}
+                      >
+                        {glyph ? (
+                          <GlyphBadge kind={glyph} theme={theme} />
+                        ) : (
+                          <div
+                            style={{
+                              display: 'flex',
+                              fontFamily: theme.bodyFont,
+                              fontSize: 13,
+                              fontWeight: highlight ? 700 : 600,
+                              color: highlight ? theme.accent : theme.ink,
+                              textAlign: 'right',
+                            }}
+                          >
+                            {value}
+                          </div>
+                        )}
+                      </div>
                     </div>
-                    <div
-                      style={{
-                        fontFamily: theme.bodyFont,
-                        fontSize: 13,
-                        fontWeight: product.highlight ? 700 : 400,
-                        color: product.highlight ? theme.accent : theme.ink,
-                        textAlign: 'right',
-                      }}
-                    >
-                      {value}
-                    </div>
-                  </div>
-                );
-              })}
+                  );
+                })}
+              </div>
             </div>
-          </div>
-        ))}
+          );
+          // Head-to-head (exactly 2 products): drop a VS medallion between them.
+          if (!mobile && module.products.length === 2 && pi === 0) {
+            return [card, <VsBadge key="vs" theme={theme} />];
+          }
+          return [card];
+        })}
       </div>
     </div>
   );
@@ -1200,11 +1395,11 @@ function DesignedSpecsOrText({
   ctx: Ctx;
 }) {
   const { theme, mobile } = ctx;
-  // Bold (tight) gets alternating row fills + accent labels; airy gets roomy
-  // hairline rows; others keep clean line-divided rows. Padding scales with density.
-  const zebra = theme.density === 'tight';
+  // Specs render as a framed card with zebra rows + accent labels across every
+  // style — a polished, scannable spec sheet beats naked hairline rows. Padding
+  // scales with density.
   const rowPadY =
-    theme.density === 'airy' ? 14 : theme.density === 'tight' ? 8 : 10;
+    theme.density === 'airy' ? 16 : theme.density === 'tight' ? 11 : 13;
   const outerPad =
     theme.density === 'airy'
       ? '12px 48px 44px'
@@ -1231,7 +1426,15 @@ function DesignedSpecsOrText({
       ) : null}
       {module.type === 'tech-specs' ? (
         <div
-          style={{ display: 'flex', flexDirection: 'column', marginTop: 14 }}
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            marginTop: 16,
+            borderRadius: theme.radius * 1.5,
+            border: `1px solid ${theme.line}`,
+            overflow: 'hidden',
+            boxShadow: '0 10px 30px rgba(0,0,0,0.05)',
+          }}
         >
           {module.rows.map((row, i) => (
             <div
@@ -1239,31 +1442,32 @@ function DesignedSpecsOrText({
               style={{
                 display: 'flex',
                 flexDirection: mobile ? 'column' : 'row',
-                padding: `${rowPadY}px ${zebra ? 14 : 0}px`,
-                background:
-                  zebra && i % 2 === 1 ? theme.surfaceAlt : 'transparent',
-                borderTop:
-                  zebra || i === 0 ? 'none' : `1px solid ${theme.line}`,
+                alignItems: mobile ? 'flex-start' : 'center',
+                padding: mobile ? '12px 18px' : `${rowPadY}px 24px`,
+                background: i % 2 === 0 ? theme.surface : theme.surfaceAlt,
               }}
             >
               <div
                 style={{
-                  width: mobile ? '100%' : 280,
+                  display: 'flex',
+                  width: mobile ? '100%' : 300,
                   marginBottom: mobile ? 2 : 0,
                   fontFamily: theme.bodyFont,
                   fontSize: 14,
-                  fontWeight: 600,
-                  color: zebra ? theme.accent : theme.ink,
+                  fontWeight: 700,
+                  letterSpacing: 0.2,
+                  color: theme.accent,
                 }}
               >
                 {row.label}
               </div>
               <div
                 style={{
+                  display: 'flex',
                   flex: mobile ? '0 1 auto' : 1,
                   fontFamily: theme.bodyFont,
-                  fontSize: 14,
-                  color: theme.muted,
+                  fontSize: 15,
+                  color: theme.ink,
                 }}
               >
                 {clean(row.value)}
@@ -1315,87 +1519,119 @@ function DesignedLogo({
   // with a brand-tinted scrim + accent flair and a heading-font tagline. The
   // logo is never AI-generated; only the backdrop is.
   const bgSrc = module.background?.image?.url;
-  // Fit the logo within a box (cap BOTH height and width) so wide wordmarks get
-  // width and tall stacked lockups don't dominate — scales to fill without
-  // forcing an oversized fixed height.
-  const logoMaxHeight = bgSrc ? (mobile ? 72 : 104) : mobile ? 64 : 92;
-  const logoMaxWidth = mobile ? 340 : 460;
-  const logo = theme.logoUrl ? (
-    <img
-      src={theme.logoUrl}
-      alt={theme.brandName || 'Brand logo'}
-      style={{
-        maxHeight: logoMaxHeight,
-        maxWidth: logoMaxWidth,
-        width: 'auto',
-        height: 'auto',
-        objectFit: 'contain',
-        display: 'block',
-      }}
-    />
-  ) : theme.brandName ? (
-    <div
-      style={{
-        fontFamily: theme.headingFont,
-        fontSize: mobile ? 34 : 52,
-        fontWeight: theme.headingWeight,
-        letterSpacing: 4,
-        textTransform: 'uppercase',
-        color: theme.ink,
-        textAlign: 'center',
-      }}
-    >
-      {theme.brandName}
-    </div>
-  ) : (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        width: 280,
-        height: 72,
-        border: `1px dashed ${theme.line}`,
-        borderRadius: theme.radius,
-        color: theme.muted,
-        fontFamily: theme.bodyFont,
-        fontSize: 13,
-      }}
-    >
-      Add your brand logo
-    </div>
-  );
   const tagline = clean(module.tagline);
-  const accentRule = (
-    <div
-      style={{
-        width: 76,
-        height: 3,
-        marginTop: 24,
-        borderRadius: 3,
-        background: theme.accent,
-      }}
-    />
-  );
-  const taglineEl = tagline ? (
-    <div
-      style={{
-        marginTop: 16,
-        maxWidth: 700,
-        fontFamily: theme.headingFont,
-        fontSize: mobile ? 17 : 22,
-        lineHeight: 1.4,
-        letterSpacing: 0.2,
-        color: theme.ink,
-        textAlign: 'center',
-      }}
-    >
-      {tagline}
-    </div>
-  ) : null;
 
-  // Brand hero with an ambient backdrop image.
-  if (bgSrc) {
+  // The logo is never AI-generated. Height-driven so the plate HUGS the mark:
+  // when the aspect is known (PNG export) we set an exact width so there are no
+  // dead margins; in the browser preview (aspect unknown) width:'auto' lets the
+  // browser size it naturally. `maxW` caps very wide wordmarks.
+  const renderLogo = (targetH: number, maxW: number) => {
+    if (theme.logoUrl) {
+      let w: number | undefined;
+      let h = targetH;
+      if (theme.logoAspect) {
+        w = Math.round(targetH * theme.logoAspect);
+        if (w > maxW) {
+          w = maxW;
+          h = Math.round(maxW / theme.logoAspect);
+        }
+      }
+      return (
+        <img
+          src={theme.logoUrl}
+          alt={theme.brandName || 'Brand logo'}
+          width={w}
+          height={h}
+          style={{
+            width: w ?? 'auto',
+            height: h,
+            maxWidth: maxW,
+            objectFit: 'contain',
+            display: 'block',
+          }}
+        />
+      );
+    }
+    return theme.brandName ? (
+      <div
+        style={{
+          display: 'flex',
+          fontFamily: theme.headingFont,
+          fontSize: mobile ? 30 : 46,
+          fontWeight: theme.headingWeight,
+          letterSpacing: 4,
+          textTransform: 'uppercase',
+          color: theme.ink,
+        }}
+      >
+        {theme.brandName}
+      </div>
+    ) : (
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 280,
+          height: 72,
+          border: `1px dashed ${theme.line}`,
+          borderRadius: theme.radius,
+          color: theme.muted,
+          fontFamily: theme.bodyFont,
+          fontSize: 13,
+        }}
+      >
+        Add your brand logo
+      </div>
+    );
+  };
+
+  // A lockup column — logo, accent rule, tagline — with alignment + sizing per use.
+  const lockup = (o: {
+    align: 'center' | 'flex-start';
+    logoW: number;
+    logoH: number;
+    taglineColor: string;
+    taglineAlign: 'center' | 'left';
+    maxTaglineW: number;
+  }) => (
+    <div
+      style={{ display: 'flex', flexDirection: 'column', alignItems: o.align }}
+    >
+      {renderLogo(o.logoH, o.logoW)}
+      <div
+        style={{
+          width: 76,
+          height: 3,
+          marginTop: 24,
+          borderRadius: 3,
+          background: theme.accent,
+        }}
+      />
+      {tagline ? (
+        <div
+          style={{
+            display: 'flex',
+            marginTop: 16,
+            maxWidth: o.maxTaglineW,
+            fontFamily: theme.headingFont,
+            fontSize: mobile ? 17 : 22,
+            lineHeight: 1.4,
+            letterSpacing: 0.2,
+            color: o.taglineColor,
+            textAlign: o.taglineAlign,
+          }}
+        >
+          {tagline}
+        </div>
+      ) : null}
+    </div>
+  );
+
+  // Brand FOOTER: a centered closing band — ornament, logo chip, tagline — over
+  // a darkened backdrop (or a dark brand band when no photo). Distinct from the
+  // left-aligned opening hero so the page reads with a clear bookend.
+  if (module.placement === 'footer') {
     return (
       <div
         style={{
@@ -1404,7 +1640,324 @@ function DesignedLogo({
           alignItems: 'center',
           justifyContent: 'center',
           width: '100%',
-          minHeight: mobile ? 320 : 420,
+          minHeight: mobile ? 220 : 280,
+          background: bgSrc ? theme.surfaceAlt : theme.ink,
+        }}
+      >
+        {bgSrc ? (
+          <div
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              display: 'flex',
+            }}
+          >
+            <img
+              src={bgSrc}
+              alt={module.background?.alt || ''}
+              style={{
+                width: '100%',
+                height: '100%',
+                objectFit: 'cover',
+                display: 'block',
+              }}
+            />
+          </div>
+        ) : null}
+        {bgSrc ? (
+          <div
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              display: 'flex',
+              background:
+                'linear-gradient(180deg, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0.72) 100%)',
+            }}
+          />
+        ) : null}
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            height: 5,
+            display: 'flex',
+            background: theme.accent,
+          }}
+        />
+        <div
+          style={{
+            position: 'relative',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: mobile ? '36px 30px' : '46px 0',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            <div style={{ width: 40, height: 2, background: theme.accent }} />
+            <div
+              style={{
+                width: 8,
+                height: 8,
+                margin: '0 10px',
+                borderRadius: 8,
+                background: theme.accent,
+              }}
+            />
+            <div style={{ width: 40, height: 2, background: theme.accent }} />
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              marginTop: 18,
+              padding: mobile ? '10px 18px' : '12px 22px',
+              borderRadius: theme.radius * 1.4,
+              background: withAlpha('#FFFFFF', 0.95),
+              boxShadow: '0 12px 30px rgba(0,0,0,0.3)',
+            }}
+          >
+            {renderLogo(mobile ? 54 : 62, mobile ? 200 : 260)}
+          </div>
+          {tagline ? (
+            <div
+              style={{
+                display: 'flex',
+                marginTop: 16,
+                maxWidth: 600,
+                fontFamily: theme.headingFont,
+                fontSize: mobile ? 15 : 19,
+                lineHeight: 1.4,
+                color: 'rgba(255,255,255,0.92)',
+                textAlign: 'center',
+              }}
+            >
+              {tagline}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+
+  // Brand hero with an ambient backdrop — the AI picks the treatment per product
+  // (module.heroVariant), so pages vary; theme/default only backstop it.
+  if (bgSrc) {
+    const variant = module.heroVariant ?? theme.heroVariant ?? 'overlay';
+
+    // OVERLAY: editorial hero — headline + benefit subhead + divider + logo
+    // lockup laid directly on a full-bleed lifestyle photo (matches premium A+
+    // brand heroes). A left-weighted scrim keeps text legible on any photo.
+    if (variant === 'overlay') {
+      const headline = clean(module.headline) || theme.brandName || '';
+      return (
+        <div
+          style={{
+            position: 'relative',
+            display: 'flex',
+            width: '100%',
+            minHeight: mobile ? 420 : 480,
+            background: theme.surfaceAlt,
+          }}
+        >
+          <div
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              display: 'flex',
+            }}
+          >
+            <img
+              src={bgSrc}
+              alt={module.background?.alt || ''}
+              style={{
+                width: '100%',
+                height: '100%',
+                objectFit: 'cover',
+                display: 'block',
+              }}
+            />
+          </div>
+          <div
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              display: 'flex',
+              background:
+                'linear-gradient(90deg, rgba(0,0,0,0.66) 0%, rgba(0,0,0,0.42) 40%, rgba(0,0,0,0.06) 100%)',
+            }}
+          />
+          <div
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              height: 5,
+              display: 'flex',
+              background: theme.accent,
+            }}
+          />
+          <div
+            style={{
+              position: 'relative',
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+              alignItems: 'flex-start',
+              width: '100%',
+              padding: mobile ? '44px 32px' : '56px 64px',
+            }}
+          >
+            {headline ? (
+              <div
+                style={{
+                  display: 'flex',
+                  maxWidth: mobile ? '100%' : 560,
+                  fontFamily: theme.headingFont,
+                  fontSize: mobile ? 34 : 50,
+                  lineHeight: 1.08,
+                  fontWeight: theme.headingWeight,
+                  letterSpacing: theme.headingTracking,
+                  textTransform: theme.headingCase,
+                  color: '#FFFFFF',
+                }}
+              >
+                {headline}
+              </div>
+            ) : null}
+            {tagline ? (
+              <div
+                style={{
+                  display: 'flex',
+                  marginTop: 14,
+                  maxWidth: mobile ? '100%' : 480,
+                  fontFamily: theme.bodyFont,
+                  fontSize: mobile ? 16 : 20,
+                  lineHeight: 1.4,
+                  color: 'rgba(255,255,255,0.92)',
+                }}
+              >
+                {tagline}
+              </div>
+            ) : null}
+          </div>
+          {/* Brand bar anchored to a bottom corner (AI-chosen side) — not floating. */}
+          <div
+            style={{
+              position: 'absolute',
+              bottom: 0,
+              ...(module.logoCorner === 'bottom-right'
+                ? { right: 0, borderTopLeftRadius: theme.radius * 2.6 }
+                : { left: 0, borderTopRightRadius: theme.radius * 2.6 }),
+              display: 'flex',
+              alignItems: 'center',
+              padding: mobile ? '12px 22px' : '14px 28px',
+              background: `linear-gradient(135deg, #FFFFFF 0%, ${theme.surfaceAlt} 100%)`,
+              borderTop: `4px solid ${theme.accent}`,
+              boxShadow: '0 -6px 22px rgba(0,0,0,0.22)',
+            }}
+          >
+            {renderLogo(mobile ? 42 : 50, mobile ? 200 : 240)}
+          </div>
+        </div>
+      );
+    }
+
+    // SPLIT: lifestyle photo beside a solid brand panel (color-blocked, bold).
+    if (variant === 'split') {
+      return (
+        <div
+          style={{
+            position: 'relative',
+            display: 'flex',
+            flexDirection: mobile ? 'column' : 'row',
+            width: '100%',
+            minHeight: mobile ? 0 : 440,
+            background: theme.surface,
+          }}
+        >
+          <div
+            style={{
+              position: 'relative',
+              display: 'flex',
+              width: mobile ? '100%' : '54%',
+              minHeight: mobile ? 240 : 0,
+            }}
+          >
+            <img
+              src={bgSrc}
+              alt={module.background?.alt || ''}
+              style={{
+                width: '100%',
+                height: '100%',
+                objectFit: 'cover',
+                display: 'block',
+              }}
+            />
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+              alignItems: 'flex-start',
+              width: mobile ? '100%' : '46%',
+              padding: mobile ? '34px 30px' : '48px 56px',
+              background: theme.surface,
+            }}
+          >
+            {lockup({
+              align: 'flex-start',
+              logoW: mobile ? 300 : 360,
+              logoH: mobile ? 84 : 120,
+              taglineColor: theme.ink,
+              taglineAlign: 'left',
+              maxTaglineW: 360,
+            })}
+          </div>
+          <div
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              height: 5,
+              display: 'flex',
+              background: theme.accent,
+            }}
+          />
+        </div>
+      );
+    }
+
+    // PLATE (solid) / GLASS (translucent): full-bleed photo + centered card.
+    const glass = variant === 'glass';
+    return (
+      <div
+        style={{
+          position: 'relative',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: '100%',
+          minHeight: mobile ? 360 : 460,
           background: theme.surfaceAlt,
         }}
       >
@@ -1429,7 +1982,6 @@ function DesignedLogo({
             }}
           />
         </div>
-        {/* Brand-tinted veil so the photo reads as an on-brand backdrop. */}
         <div
           style={{
             position: 'absolute',
@@ -1438,13 +1990,10 @@ function DesignedLogo({
             right: 0,
             bottom: 0,
             display: 'flex',
-            background: `linear-gradient(180deg, ${withAlpha(
-              theme.bg,
-              0.74
-            )} 0%, ${withAlpha(theme.bg, 0.86)} 100%)`,
+            background:
+              'linear-gradient(180deg, rgba(0,0,0,0.32) 0%, rgba(0,0,0,0.12) 42%, rgba(0,0,0,0.40) 100%)',
           }}
         />
-        {/* Accent flair bar across the top. */}
         <div
           style={{
             position: 'absolute',
@@ -1463,18 +2012,31 @@ function DesignedLogo({
             flexDirection: 'column',
             alignItems: 'center',
             justifyContent: 'center',
-            padding: mobile ? '44px 28px' : '60px 0',
+            padding: mobile ? '30px 34px' : '40px 72px',
+            borderRadius: theme.radius * 1.6,
+            background: glass ? withAlpha('#FFFFFF', 0.7) : theme.surface,
+            border: `1px solid ${
+              glass ? withAlpha('#FFFFFF', 0.55) : withAlpha(theme.ink, 0.06)
+            }`,
+            boxShadow: '0 24px 60px rgba(0,0,0,0.34)',
           }}
         >
-          {logo}
-          {accentRule}
-          {taglineEl}
+          {lockup({
+            align: 'center',
+            logoW: mobile ? 340 : 440,
+            logoH: mobile ? 88 : 128,
+            taglineColor: theme.ink,
+            taglineAlign: 'center',
+            maxTaglineW: 640,
+          })}
         </div>
       </div>
     );
   }
 
-  // Fallback: tinted band (no backdrop) with a large logo.
+  // Fallback (no AI backdrop): a large logo in a soft raised panel on a subtle
+  // brand gradient, so the header reads as an intentional brand lockup rather
+  // than an empty band. Satori-safe: flexbox + linear-gradient + boxShadow only.
   return (
     <div
       style={{
@@ -1483,14 +2045,34 @@ function DesignedLogo({
         alignItems: 'center',
         justifyContent: 'center',
         width: '100%',
-        background: theme.surfaceAlt,
+        background: `linear-gradient(160deg, ${
+          theme.surfaceAlt
+        } 0%, ${withAlpha(theme.accent, 0.1)} 100%)`,
         borderTop: `5px solid ${theme.accent}`,
-        padding: mobile ? '40px 24px' : '56px 0',
+        padding: mobile ? '36px 24px' : '48px 0',
       }}
     >
-      {logo}
-      {accentRule}
-      {taglineEl}
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          padding: mobile ? '28px 32px' : '40px 64px',
+          borderRadius: theme.radius * 1.5,
+          background: theme.surface,
+          border: `1px solid ${theme.line}`,
+          boxShadow: '0 18px 44px rgba(0,0,0,0.10)',
+        }}
+      >
+        {lockup({
+          align: 'center',
+          logoW: mobile ? 340 : 500,
+          logoH: mobile ? 104 : 168,
+          taglineColor: theme.ink,
+          taglineAlign: 'center',
+          maxTaglineW: 640,
+        })}
+      </div>
     </div>
   );
 }
@@ -1630,6 +2212,278 @@ function DesignedDualUse({
   );
 }
 
+/**
+ * Generic lucide-style icon paths (stroke), drawn as inline <svg>. Inline SVG
+ * renders both in the browser preview and in satori/next-og export.
+ */
+const ICON_PATHS: Record<IconRowIcon, string[]> = {
+  coffee: [
+    'M17 8h1a4 4 0 1 1 0 8h-1',
+    'M3 8h14v9a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4Z',
+    'M6 2v2',
+    'M10 2v2',
+    'M14 2v2',
+  ],
+  leaf: [
+    'M11 20A7 7 0 0 1 9.8 6.1C15.5 5 17 4.48 19 2c1 2 2 4.18 2 8 0 5.5-4.78 10-10 10Z',
+    'M2 21c0-3 1.85-5.36 5.08-6',
+  ],
+  shield: [
+    'M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z',
+  ],
+  zap: [
+    'M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z',
+  ],
+  heart: [
+    'M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z',
+  ],
+  star: [
+    'M11.5 2.3a.5.5 0 0 1 1 0l2.6 5.3 5.8.8a.5.5 0 0 1 .3.9l-4.2 4 1 5.8a.5.5 0 0 1-.8.5L12 19l-5.2 2.7a.5.5 0 0 1-.7-.5l1-5.8-4.2-4a.5.5 0 0 1 .3-.9l5.8-.8z',
+  ],
+  package: [
+    'M11 21.7a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16V8a2 2 0 0 0-1-1.7l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.7z',
+    'M3.3 7 12 12l8.7-5',
+    'M12 22V12',
+  ],
+  home: [
+    'M3 10a2 2 0 0 1 .7-1.5l7-6a2 2 0 0 1 2.6 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z',
+    'M9 21v-6a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v6',
+  ],
+  gift: [
+    'M20 12v10H4V12',
+    'M2 7h20v5H2z',
+    'M12 22V7',
+    'M12 7H7.5a2.5 2.5 0 0 1 0-5C11 2 12 7 12 7Z',
+    'M12 7h4.5a2.5 2.5 0 0 0 0-5C13 2 12 7 12 7Z',
+  ],
+  sparkles: [
+    'M9.9 15.5A2 2 0 0 0 8.5 14.1l-6.1-1.6a.5.5 0 0 1 0-1L8.5 9.9A2 2 0 0 0 9.9 8.5l1.6-6.1a.5.5 0 0 1 1 0L14.1 8.5A2 2 0 0 0 15.5 9.9l6.1 1.6a.5.5 0 0 1 0 1L15.5 14.1a2 2 0 0 0-1.4 1.4l-1.6 6.1a.5.5 0 0 1-1 0z',
+  ],
+  building: [
+    'M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z',
+    'M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2',
+    'M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2',
+    'M10 6h4',
+    'M10 10h4',
+    'M10 14h4',
+  ],
+  users: [
+    'M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2',
+    'M9 7a4 4 0 1 0 0 8 4 4 0 0 0 0-8Z',
+    'M22 21v-2a4 4 0 0 0-3-3.9',
+    'M16 3.1a4 4 0 0 1 0 7.8',
+  ],
+  check: ['M20 6 9 17l-5-5'],
+  clock: ['M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Z', 'M12 6v6l4 2'],
+  droplet: [
+    'M12 22a7 7 0 0 0 7-7c0-2-1-3.9-3-5.5s-3.5-4-4-6.5c-.5 2.5-2 4.9-4 6.5C4 11.1 3 13 3 15a7 7 0 0 0 7 7Z',
+  ],
+  thermometer: ['M14 4v10.5a4 4 0 1 1-4 0V4a2 2 0 0 1 4 0Z'],
+};
+
+/** Map common/intuitive icon names the model emits to a supported glyph. */
+const ICON_ALIASES: Record<string, IconRowIcon> = {
+  mug: 'coffee',
+  cup: 'coffee',
+  espresso: 'coffee',
+  latte: 'coffee',
+  beverage: 'coffee',
+  tea: 'droplet',
+  drink: 'droplet',
+  water: 'droplet',
+  liquid: 'droplet',
+  hydration: 'droplet',
+  office: 'building',
+  work: 'building',
+  business: 'building',
+  commercial: 'building',
+  workplace: 'building',
+  cafe: 'building',
+  restaurant: 'building',
+  event: 'users',
+  events: 'users',
+  party: 'users',
+  people: 'users',
+  community: 'users',
+  group: 'users',
+  team: 'users',
+  family: 'users',
+  social: 'users',
+  calendar: 'clock',
+  schedule: 'clock',
+  time: 'clock',
+  date: 'clock',
+  duration: 'clock',
+  timer: 'clock',
+  eco: 'leaf',
+  recycle: 'leaf',
+  green: 'leaf',
+  sustainable: 'leaf',
+  plant: 'leaf',
+  natural: 'leaf',
+  biodegradable: 'leaf',
+  compostable: 'leaf',
+  organic: 'leaf',
+  durable: 'shield',
+  protect: 'shield',
+  protection: 'shield',
+  safe: 'shield',
+  secure: 'shield',
+  safety: 'shield',
+  warranty: 'shield',
+  guarantee: 'shield',
+  sturdy: 'shield',
+  fast: 'zap',
+  power: 'zap',
+  energy: 'zap',
+  quick: 'zap',
+  instant: 'zap',
+  performance: 'zap',
+  powerful: 'zap',
+  quality: 'star',
+  premium: 'star',
+  award: 'star',
+  best: 'star',
+  rating: 'star',
+  certified: 'star',
+  excellence: 'star',
+  trusted: 'star',
+  love: 'heart',
+  comfort: 'heart',
+  care: 'heart',
+  favorite: 'heart',
+  comfortable: 'heart',
+  cozy: 'heart',
+  ship: 'package',
+  shipping: 'package',
+  delivery: 'package',
+  box: 'package',
+  bundle: 'package',
+  kit: 'package',
+  pack: 'package',
+  value: 'package',
+  bulk: 'package',
+  thermal: 'thermometer',
+  hot: 'thermometer',
+  cold: 'thermometer',
+  temperature: 'thermometer',
+  insulated: 'thermometer',
+  insulation: 'thermometer',
+  heat: 'thermometer',
+  house: 'home',
+  household: 'home',
+  domestic: 'home',
+  present: 'gift',
+  sparkle: 'sparkles',
+  shine: 'sparkles',
+  clean: 'sparkles',
+  new: 'sparkles',
+  fresh: 'sparkles',
+  verified: 'check',
+  yes: 'check',
+  included: 'check',
+  tick: 'check',
+  done: 'check',
+};
+
+function resolveIcon(name: string): IconRowIcon {
+  const k = name.trim().toLowerCase();
+  if (k in ICON_PATHS) return k as IconRowIcon;
+  return ICON_ALIASES[k] ?? 'check';
+}
+
+/** A horizontal strip of icon + label highlights (use cases / key benefits). */
+function DesignedIconRow({
+  module,
+  ctx,
+}: {
+  module: Extract<APlusGeneratedModule, { type: 'icon-row' }>;
+  ctx: Ctx;
+}) {
+  const { theme, mobile } = ctx;
+  const iconSize = mobile ? 24 : 28;
+  const circle = mobile ? 46 : 56;
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        width: '100%',
+        background: theme.bg,
+        paddingBottom: mobile ? 22 : 28,
+      }}
+    >
+      <SectionTitle title={module.title} theme={theme} />
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: mobile ? 'column' : 'row',
+          alignItems: 'stretch',
+          justifyContent: 'center',
+          padding: mobile ? '10px 24px 0' : '16px 30px 0',
+        }}
+      >
+        {module.items.map((item, i) => (
+          <div
+            key={i}
+            style={{
+              display: 'flex',
+              flexDirection: mobile ? 'row' : 'column',
+              alignItems: 'center',
+              justifyContent: mobile ? 'flex-start' : 'center',
+              flex: 1,
+              padding: mobile ? '12px 0' : '6px 10px',
+              borderLeft: !mobile && i > 0 ? `1px solid ${theme.line}` : 'none',
+              borderTop: mobile && i > 0 ? `1px solid ${theme.line}` : 'none',
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: circle,
+                height: circle,
+                borderRadius: circle,
+                background: theme.accentSoft,
+                marginRight: mobile ? 14 : 0,
+                marginBottom: mobile ? 0 : 12,
+              }}
+            >
+              <svg
+                width={iconSize}
+                height={iconSize}
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke={theme.accent}
+                strokeWidth={2}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                {ICON_PATHS[resolveIcon(item.icon)].map((d, j) => (
+                  <path key={j} d={d} />
+                ))}
+              </svg>
+            </div>
+            <div
+              style={{
+                display: 'flex',
+                fontFamily: theme.bodyFont,
+                fontSize: mobile ? 15 : 14,
+                fontWeight: 600,
+                color: theme.ink,
+                textAlign: 'center',
+              }}
+            >
+              {clean(item.label)}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 /** Designed (branded) render of one module — used by preview and PNG export. */
 export function DesignedModule({
   module,
@@ -1665,6 +2519,8 @@ export function DesignedModule({
       return <DesignedSpecsOrText module={module} ctx={ctx} />;
     case 'dual-use-split':
       return <DesignedDualUse module={module} ctx={ctx} />;
+    case 'icon-row':
+      return <DesignedIconRow module={module} ctx={ctx} />;
     default:
       return null;
   }

--- a/apps/web/src/app/(dashboard)/brand-guides/page.tsx
+++ b/apps/web/src/app/(dashboard)/brand-guides/page.tsx
@@ -3,12 +3,14 @@
 import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import {
+  AlertTriangle,
   ArrowLeft,
   BookTemplate,
   CheckCircle2,
   FileUp,
   Globe,
   ImageIcon,
+  ImageOff,
   Loader2,
   Plus,
   Trash2,
@@ -135,6 +137,102 @@ function formatGuideUpdatedAt(timestamp: number) {
     day: 'numeric',
     year: 'numeric',
   }).format(timestamp);
+}
+
+/**
+ * Chip showing the uploaded logo with its file metadata. When the thumbnail
+ * can't be fetched, we no longer silently hide it (which left only the bare
+ * filename, reading as "it's showing the filename instead of my logo"). Instead
+ * we show a clear failed-load state and probe `/assets/health` to tell a
+ * transient storage/session problem (e.g. an expired AWS SSO session) apart
+ * from a genuinely broken asset, so the message points at the real fix.
+ */
+function UploadedLogoPreview({
+  asset,
+  onRemove,
+}: {
+  asset: NonNullable<BrandGuide['logoAsset']>;
+  onRemove: () => void;
+}) {
+  const [failed, setFailed] = useState(false);
+  const [storageDown, setStorageDown] = useState(false);
+
+  // A new asset (re-upload / switching guides) gets a fresh attempt.
+  useEffect(() => {
+    setFailed(false);
+    setStorageDown(false);
+  }, [asset.assetId]);
+
+  async function handleError() {
+    setFailed(true);
+    try {
+      const response = await fetch('/api/a-plus/assets/health');
+      const body = (await response.json().catch(() => null)) as {
+        ok?: boolean;
+      } | null;
+      setStorageDown(!body?.ok);
+    } catch {
+      setStorageDown(true);
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-3 rounded-md border bg-background px-3 py-2">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded border bg-white">
+            {failed ? (
+              <ImageOff className="h-5 w-5 text-muted-foreground" />
+            ) : (
+              <img
+                src={`/api/a-plus/assets/${asset.assetId}`}
+                alt={asset.originalFileName}
+                className="max-h-12 max-w-full object-contain"
+                onError={handleError}
+              />
+            )}
+          </div>
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium">
+              {asset.originalFileName}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {asset.mimeType} · {formatBytes(asset.sizeBytes)}
+            </p>
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 shrink-0 text-muted-foreground"
+          onClick={onRemove}
+        >
+          <Trash2 className="h-4 w-4" />
+          <span className="sr-only">Remove logo</span>
+        </Button>
+      </div>
+      {failed && (
+        <p className="flex items-start gap-2 text-xs text-amber-600">
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>
+            {storageDown ? (
+              <>
+                Logo preview couldn’t load — media storage isn’t reachable. Your
+                AWS session may have expired; run{' '}
+                <code className="rounded bg-amber-100 px-1 py-0.5 font-mono">
+                  aws sso login
+                </code>{' '}
+                and reload. The logo file is still saved with this guide.
+              </>
+            ) : (
+              'Logo preview couldn’t load. The logo file is still saved with this guide.'
+            )}
+          </span>
+        </p>
+      )}
+    </div>
+  );
 }
 
 function describeGuideCoverage(guide: BrandGuide) {
@@ -1511,47 +1609,15 @@ export default function BrandGuidesPage() {
                     />
                   </label>
                   {draftGuide.logoAsset && (
-                    <div className="flex items-center justify-between gap-3 rounded-md border bg-background px-3 py-2">
-                      <div className="flex min-w-0 items-center gap-3">
-                        <div className="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded border bg-white">
-                          {/* Preview the actual uploaded logo. If the asset can't
-                              be fetched (e.g. storage not signed in) the image
-                              hides itself rather than showing a broken icon. */}
-                          <img
-                            src={`/api/a-plus/assets/${draftGuide.logoAsset.assetId}`}
-                            alt={draftGuide.logoAsset.originalFileName}
-                            className="max-h-12 max-w-full object-contain"
-                            onError={(event) => {
-                              event.currentTarget.style.display = 'none';
-                            }}
-                          />
-                        </div>
-                        <div className="min-w-0">
-                          <p className="truncate text-sm font-medium">
-                            {draftGuide.logoAsset.originalFileName}
-                          </p>
-                          <p className="text-xs text-muted-foreground">
-                            {draftGuide.logoAsset.mimeType} ·{' '}
-                            {formatBytes(draftGuide.logoAsset.sizeBytes)}
-                          </p>
-                        </div>
-                      </div>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        className="h-8 w-8 shrink-0 text-muted-foreground"
-                        onClick={() =>
-                          setDraftGuide((current) => ({
-                            ...current,
-                            logoAsset: undefined,
-                          }))
-                        }
-                      >
-                        <Trash2 className="h-4 w-4" />
-                        <span className="sr-only">Remove logo</span>
-                      </Button>
-                    </div>
+                    <UploadedLogoPreview
+                      asset={draftGuide.logoAsset}
+                      onRemove={() =>
+                        setDraftGuide((current) => ({
+                          ...current,
+                          logoAsset: undefined,
+                        }))
+                      }
+                    />
                   )}
                 </div>
 

--- a/apps/web/src/app/api/a-plus/assets/[assetId]/route.ts
+++ b/apps/web/src/app/api/a-plus/assets/[assetId]/route.ts
@@ -1,10 +1,25 @@
 import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import sharp from 'sharp';
 import { auth0 } from '../../../../../lib/auth0';
 import { createAssetS3Client, getAsset } from '../../../../../lib/media-assets';
 
+// sharp requires the Node runtime.
+export const runtime = 'nodejs';
+
 const SIGNED_URL_TTL_SECONDS = 300;
 const BROWSER_CACHE_SECONDS = 240;
+// Thumbnails are immutable per asset id, so cache them hard.
+const THUMB_CACHE_SECONDS = 60 * 60 * 24 * 30;
+const MIN_THUMB_WIDTH = 16;
+const MAX_THUMB_WIDTH = 1024;
+
+function parseThumbWidth(value: string | null): number | null {
+  if (!value) return null;
+  const width = Number.parseInt(value, 10);
+  if (!Number.isFinite(width)) return null;
+  return Math.min(MAX_THUMB_WIDTH, Math.max(MIN_THUMB_WIDTH, width));
+}
 
 function sanitizeDownloadName(value: string, fallback: string): string {
   const cleaned = value
@@ -48,6 +63,41 @@ export async function GET(
   }
 
   const url = new URL(request.url);
+
+  // Thumbnail path: `?w=<px>` streams a server-resized PNG (cheap, cacheable)
+  // instead of redirecting to the full-resolution original. Any failure falls
+  // through to the full-res signed-URL path below so previews still work.
+  const thumbWidth = parseThumbWidth(url.searchParams.get('w'));
+  if (thumbWidth) {
+    try {
+      const object = await createAssetS3Client().send(
+        new GetObjectCommand({
+          Bucket: asset.storage.bucket,
+          Key: asset.storage.key,
+        })
+      );
+      const bytes = await object.Body?.transformToByteArray();
+      if (bytes) {
+        const png = await sharp(Buffer.from(bytes), { density: 240 })
+          .resize({
+            width: thumbWidth,
+            fit: 'inside',
+            withoutEnlargement: true,
+          })
+          .png()
+          .toBuffer();
+        return new Response(new Uint8Array(png), {
+          headers: {
+            'Content-Type': 'image/png',
+            'Cache-Control': `private, max-age=${THUMB_CACHE_SECONDS}, immutable`,
+          },
+        });
+      }
+    } catch {
+      // Fall through to the full-resolution signed URL below.
+    }
+  }
+
   const download = url.searchParams.get('download') === '1';
   const requestedName = url.searchParams.get('filename') || '';
   const downloadName = download

--- a/apps/web/src/app/api/a-plus/assets/[assetId]/route.ts
+++ b/apps/web/src/app/api/a-plus/assets/[assetId]/route.ts
@@ -11,14 +11,23 @@ const SIGNED_URL_TTL_SECONDS = 300;
 const BROWSER_CACHE_SECONDS = 240;
 // Thumbnails are immutable per asset id, so cache them hard.
 const THUMB_CACHE_SECONDS = 60 * 60 * 24 * 30;
-const MIN_THUMB_WIDTH = 16;
-const MAX_THUMB_WIDTH = 1024;
+// Fixed thumbnail widths. Snapping `?w=` to this small set bounds the number of
+// distinct cache keys (and on-the-fly resizes) a caller can request, so varying
+// `w` can't be used to bypass caching and force repeated S3 fetch + decode.
+const THUMB_WIDTHS = [160, 320, 640, 1024] as const;
+// Cap decode work on a crafted/oversized upload (well above any real product
+// photo). sharp's ~268MP default is the backstop; this is the explicit limit.
+const MAX_INPUT_PIXELS = 64_000_000;
 
 function parseThumbWidth(value: string | null): number | null {
   if (!value) return null;
-  const width = Number.parseInt(value, 10);
-  if (!Number.isFinite(width)) return null;
-  return Math.min(MAX_THUMB_WIDTH, Math.max(MIN_THUMB_WIDTH, width));
+  const requested = Number.parseInt(value, 10);
+  if (!Number.isFinite(requested)) return null;
+  // Smallest bucket that satisfies the request, else the largest.
+  return (
+    THUMB_WIDTHS.find((width) => width >= requested) ??
+    THUMB_WIDTHS[THUMB_WIDTHS.length - 1]
+  );
 }
 
 function sanitizeDownloadName(value: string, fallback: string): string {
@@ -78,7 +87,10 @@ export async function GET(
       );
       const bytes = await object.Body?.transformToByteArray();
       if (bytes) {
-        const png = await sharp(Buffer.from(bytes), { density: 240 })
+        const png = await sharp(Buffer.from(bytes), {
+          density: 240,
+          limitInputPixels: MAX_INPUT_PIXELS,
+        })
           .resize({
             width: thumbWidth,
             fit: 'inside',

--- a/apps/web/src/app/api/a-plus/drafts/[draftId]/route.ts
+++ b/apps/web/src/app/api/a-plus/drafts/[draftId]/route.ts
@@ -3,6 +3,7 @@ import {
   deleteAPlusDraft,
   getAPlusDraft,
 } from '../../../../../lib/a-plus-drafts';
+import { cleanupDeletedDraftAssets } from '../../../../../lib/a-plus-asset-cleanup';
 
 export async function GET(
   _request: Request,
@@ -32,6 +33,22 @@ export async function DELETE(
   }
 
   const { draftId } = await params;
+  // Load before deleting so we know which generated images this draft owned.
+  const draft = await getAPlusDraft({ userId: session.user.sub, draftId });
   await deleteAPlusDraft({ userId: session.user.sub, draftId });
+
+  if (draft) {
+    // Best-effort: delete generated images no other draft/guide references.
+    try {
+      await cleanupDeletedDraftAssets({
+        userId: session.user.sub,
+        draftId,
+        draft,
+      });
+    } catch {
+      // Swallow — leftover assets are harmless storage, not a delete failure.
+    }
+  }
+
   return Response.json({ ok: true });
 }

--- a/apps/web/src/app/api/a-plus/drafts/route.ts
+++ b/apps/web/src/app/api/a-plus/drafts/route.ts
@@ -5,6 +5,7 @@ import {
   listAPlusDrafts,
   upsertAPlusDraft,
 } from '../../../../lib/a-plus-drafts';
+import { cleanupSupersededDraftAssets } from '../../../../lib/a-plus-asset-cleanup';
 
 export async function GET() {
   const session = await auth0.getSession();
@@ -64,6 +65,20 @@ export async function POST(request: Request) {
     packageJson: body.packageJson,
     createdAt: existing?.createdAt,
   });
+
+  // Free generated images this save dropped (e.g. a refreshed slot) once
+  // nothing else references them. Best-effort: never fail a save on cleanup.
+  try {
+    await cleanupSupersededDraftAssets({
+      userId: session.user.sub,
+      draftId,
+      oldDraft: existing,
+      newPayload: body.payload ?? {},
+      newPackageJson: body.packageJson,
+    });
+  } catch {
+    // Swallow — orphaned assets are harmless and get swept on the next save.
+  }
 
   return Response.json({ draft });
 }

--- a/apps/web/src/app/api/a-plus/generate/route.ts
+++ b/apps/web/src/app/api/a-plus/generate/route.ts
@@ -331,6 +331,15 @@ function buildPackageOuterFromStrategy(
   };
 }
 
+// OpenAI models default to STRICT JSON-schema structured outputs in AI SDK v6,
+// which reject our discriminated-union/optional package schema. Anthropic's
+// structured output is tool-based and lenient (which is why Claude works), so we
+// turn strict mode off for OpenAI. Keyed under `openai`, so it's ignored by
+// Anthropic and other providers — safe to pass on every call.
+const STRUCTURED_OUTPUT_PROVIDER_OPTIONS = {
+  openai: { strictJsonSchema: false },
+} as const;
+
 function createProvider(modelOverride?: string) {
   // A valid allowlisted override drives BOTH tiers (the generator runs on the
   // 'fast' tier); otherwise fall back to env config / built-in defaults.
@@ -508,6 +517,7 @@ async function generateModulesSingle(
         // All modules in one object is token-heavy — give it ample room so the
         // JSON is never truncated (truncation reads as a schema mismatch).
         maxOutputTokens: 32000,
+        providerOptions: STRUCTURED_OUTPUT_PROVIDER_OPTIONS,
         output: Output.object({
           schema: z.object({ modules: z.array(APlusGeneratedModuleSchema) }),
           name: 'a_plus_package_modules',
@@ -573,6 +583,7 @@ async function generateModulesParallel(
           const res = await generateText({
             model: provider.languageModel('fast'),
             abortSignal: AbortSignal.timeout(90_000),
+            providerOptions: STRUCTURED_OUTPUT_PROVIDER_OPTIONS,
             output: Output.object({
               schema: generatedModuleSchemaForKind(kind),
               name: 'a_plus_module',
@@ -718,6 +729,7 @@ export async function POST(request: Request) {
         const strategyResult = await generateText({
           model: provider.languageModel('fast'),
           abortSignal: AbortSignal.timeout(120_000),
+          providerOptions: STRUCTURED_OUTPUT_PROVIDER_OPTIONS,
           output: Output.object({
             schema: strategySchema,
             name: 'a_plus_content_strategy',
@@ -755,6 +767,7 @@ export async function POST(request: Request) {
           ? await generateText({
               model: provider.languageModel('fast'),
               abortSignal: AbortSignal.timeout(45_000),
+              providerOptions: STRUCTURED_OUTPUT_PROVIDER_OPTIONS,
               output: Output.object({
                 schema: packageOuterSchema,
                 name: 'a_plus_content_package_outer',

--- a/apps/web/src/app/api/a-plus/generate/route.ts
+++ b/apps/web/src/app/api/a-plus/generate/route.ts
@@ -371,7 +371,8 @@ function compactInput(input: z.infer<typeof requestSchema>) {
         contentTier: input.contentTier,
         oneLiner: input.productOneLiner,
         targetCustomer: input.targetCustomer,
-        pricePoint: input.pricePoint,
+        // Price is intentionally NOT sent: A+ content never displays price and
+        // extracted prices are unreliable. Omitting it keeps it out of copy.
         keyFeatures: input.keyFeatures,
         differentiators: input.differentiators,
         objections: input.objections,
@@ -447,6 +448,8 @@ function classifyError(detail: string, phase: string) {
 
 /** Per-module field rules shared by both generation strategies. */
 const MODULE_FIELD_RULES: string[] = [
+  'SUBJECT PRODUCT ONLY: describe and depict OUR product (the "Product listing" source / product facts). Competitor, Supplier, and Reference sources are DIFFERENT products — use them ONLY for comparison-table contrasts and positioning. NEVER attribute their color, size, materials, pack count, lids, or features to our product, in copy OR in image briefs.',
+  'NEVER mention price, discounts, or promotions anywhere — A+ content stays live indefinitely and Amazon rejects time-sensitive claims.',
   'TEXT FIELDS — write real CUSTOMER-FACING copy the buyer reads. Not design notes, not descriptions of the layout.',
   '  • headline: ≤8 words, a concrete benefit. body: 1–3 sentences of durable benefit/use-case copy. bullets: ≤90 chars each, benefit statements.',
   '  • company-logo: a full-bleed brand HERO. Set headline to the brand name plus a short product descriptor — the hero line, ≤8 words (e.g. “<Brand> <Product Category>”). Set tagline to a short (≤10 words) durable benefit/brand-promise subhead. Both must suit THIS product (any category — never assume a specific one). No price/claims. ALSO choose a hero TREATMENT that best fits this product so pages do not all look identical: set heroVariant to one of overlay | split | plate | glass, and (only for overlay) set logoCorner to bottom-left or bottom-right. Vary this choice per product based on the brand mood — do NOT default every product to the same one.',
@@ -747,7 +750,8 @@ export async function POST(request: Request) {
             )} modulePlan entries that tell THIS product's story end to end. This is the final module sequence.`,
             'STRUCTURE MUST BE DYNAMIC, not a fixed template: decide the opening, the mix of module types, and their order based on what THIS specific product needs to persuade its buyer. Two different products should produce noticeably different structures — vary which modules appear and in what sequence. Do not default to one canonical order.',
             'Use a VARIETY of distinct module types (each renders as a different layout). Open with a strong hero or brand moment, then sequence the rest into the most persuasive narrative for this product (features, real-life use cases, dual-use scenarios, proof/specs, comparison, brand story) — in whatever order fits best. Avoid repeating the same moduleType.',
-            'NEVER plan modules around price points, discounts, promotions, delivery times, shipping speed, stock levels, or any time-sensitive claim. A+ Content stays live indefinitely; these go stale fast and Amazon rejects them. Use price input only as positioning context (premium vs value tier) — do not surface the number anywhere in module copy.',
+            'NEVER plan modules around price points, discounts, promotions, delivery times, shipping speed, stock levels, or any time-sensitive claim. A+ Content stays live indefinitely; these go stale fast and Amazon rejects them.',
+            'Competitor/Reference/Supplier sources are DIFFERENT products. Use them only to inform comparison and positioning — NEVER let their attributes (color, size, materials, pack count, finishes) define our product’s appearance or the visual system.',
             '',
             context,
           ].join('\n'),
@@ -832,6 +836,7 @@ export async function POST(request: Request) {
           `  • SAME HERO PRODUCT in every image: ${humanProductName(
             input
           )}. Describe its material, color, finish, shape, and proportions IDENTICALLY across all modules so it is unmistakably the same physical product.`,
+          '  • Base the product’s appearance ONLY on OUR product facts. Competitor/Reference sources are DIFFERENT products — NEVER borrow their colors, lids, sizes, materials, or finishes (e.g. a competitor’s brown cups must not turn our product brown).',
           `  • ONE consistent look everywhere: ${outer.creativeDirection.visualSystem} Keep the same color palette, the same lighting direction & quality (e.g. soft warm window light from one side), the same lens/perspective character, and the same mood in every shot.`,
           '  • Treat all module images as frames from ONE cohesive premium photoshoot — never disparate stock photos with different products, lighting, or color grading.',
         ].join('\n');

--- a/apps/web/src/app/api/a-plus/generate/route.ts
+++ b/apps/web/src/app/api/a-plus/generate/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { createAIProvider } from '@amz-spapi/ai-provider';
 import {
   APlusGeneratedModuleSchema,
+  ICON_ROW_ICONS,
   RENDERABLE_AMAZON_MODULE_TYPES,
   type RenderableAmazonModuleType,
   amazonModuleTypeToKind,
@@ -439,20 +440,24 @@ function classifyError(detail: string, phase: string) {
 const MODULE_FIELD_RULES: string[] = [
   'TEXT FIELDS — write real CUSTOMER-FACING copy the buyer reads. Not design notes, not descriptions of the layout.',
   '  • headline: ≤8 words, a concrete benefit. body: 1–3 sentences of durable benefit/use-case copy. bullets: ≤90 chars each, benefit statements.',
-  '  • company-logo: set tagline to a short (≤10 words) durable brand promise shown under the logo — e.g. “Insulated kraft cups built for specialty coffee service.” No price/claims.',
+  '  • company-logo: a full-bleed brand HERO. Set headline to the brand name plus a short product descriptor — the hero line, ≤8 words (e.g. “<Brand> <Product Category>”). Set tagline to a short (≤10 words) durable benefit/brand-promise subhead. Both must suit THIS product (any category — never assume a specific one). No price/claims. ALSO choose a hero TREATMENT that best fits this product so pages do not all look identical: set heroVariant to one of overlay | split | plate | glass, and (only for overlay) set logoCorner to bottom-left or bottom-right. Vary this choice per product based on the brand mood — do NOT default every product to the same one.',
   '  • hero modules (image-header-with-text / image-text-overlay / single-image-text / image-and-text): set badge to a SHORT spec/size pill (≤12 chars, e.g. “16 OZ”, “50-PACK”, “BPA-FREE”) when an obvious size/spec applies; omit otherwise. Never price or promo.',
   '  • comparison-table: products[].title are the column labels; rows[] are spec/benefit rows with exactly one value per product (same order). Set highlight=true on the seller’s own product.',
   '  • tech-specs: rows[] are {label, value} product facts (dimensions, materials, care, compatibility, package contents).',
   '  • dual-use-split: exactly 2 panels showing two CONTRASTING use scenarios of the SAME product (e.g. “Hot Beverages” vs “Cold Drinks”, “Indoor” vs “Outdoor”). Each panel: a short uppercase label (≤3 words), an optional ≤120-char caption, and an image slot whose brief depicts that exact scenario with the same product/look.',
+  `  • icon-row: 3–5 items, each {icon, label} — a quick scannable strip of use cases or key benefits. label ≤2 words. icon is a short lowercase keyword that suits the item — prefer one of: ${ICON_ROW_ICONS.join(
+    ', '
+  )} (a close synonym like office/event/eco/premium also works; it is mapped to a glyph). No images.`,
   '',
   'IMAGE SLOTS — every image slot describes a PHOTOGRAPH to be generated or uploaded later. For each slot provide role, size, alt, and brief. DO NOT output an "image" field; slots are filled downstream.',
   '  • role: short stable id (e.g. "hero", "column-1", "comparison-thumb-1").',
   '  • size: 1792x1024 for a wide hero/banner; 1024x1024 for square feature/column/grid images; 1024x1792 only when a tall portrait genuinely helps.',
   '  • alt: ≤160 char description of the photo content. No brand names.',
   '  • brief: a CINEMATIC, ASPIRATIONAL LIFESTYLE photographic prompt of 4–6 sentences — the kind of premium imagery in a high-end brand campaign, NOT a plain product shot. Prefer real people / hands actively USING the product in a believable moment, in a specific aspirational named environment (e.g. a sunlit specialty café, a modern kitchen at golden hour). It must name: the human action/moment, the hero product in genuine use, 3–5 atmospheric props, a specific surface + directional natural light source + ambient background depth, cinematic editorial lighting (soft window light, warm golden hour, etc.), shallow depth of field with foreground/mid/background layers, and a refined premium brand mood. Avoid flat-lay, isolated-on-white, studio-seamless, stock-photo stiffness, and minimalist-whitespace defaults.',
+  '  • NO ABSTRACT / CGI SLOP: every image is a believable REAL PHOTOGRAPH of the actual product. NEVER ask for cutaways, cross-sections, exploded views, technical/engineering diagrams, schematics, infographics, 3D-render or CGI looks, extreme material macros, or floating/isolated concept shots. For a feature/benefit cell, show the product in a real context that IMPLIES the benefit (e.g. the cup comfortably held, a neat stack on a counter) — never a diagram OF the benefit.',
   '  • CONTINUITY: every brief MUST restate the SAME product (same material/color/finish/shape per the SHOT BIBLE) and the SAME lighting, palette, lens and mood, so all images look like one shoot.',
   '  • CRITICAL: the brief must NEVER ask for any rendered text, headline, label, callout, price, watermark, badge, or logo. All text lives in the HTML fields above, never baked into pixels.',
-  '  • company-logo background slot: an AMBIENT, on-brand atmosphere photo (soft out-of-focus environment, warm bokeh, brand-colored mood) that sits BEHIND the logo under a tint — keep it soft, low-contrast, and uncluttered, with NO product hero front-and-center, no people staring, no text.',
+  '  • company-logo background slot: ALWAYS include a background slot for every company-logo module — the header is a brand HERO, never a bare logo. It is an AMBIENT, on-brand LIFESTYLE photo of the real environment where THIS product is used or displayed — chosen to fit the product category, NOT any fixed theme (e.g. a sunlit kitchen counter, a modern desk, a styled shelf, an outdoor patio — whatever suits the product). COMPOSE it with the hero subject toward ONE side and clean, low-detail NEGATIVE SPACE on the OPPOSITE side so the overlaid headline/subhead stays legible. Soft out-of-focus depth, gentle bokeh, premium natural light. No text, no logos, no people staring at camera.',
 ];
 
 type ModuleGenContext = {
@@ -500,6 +505,9 @@ async function generateModulesSingle(
       const res = await generateText({
         model: provider.languageModel('fast'),
         abortSignal: AbortSignal.timeout(180_000),
+        // All modules in one object is token-heavy — give it ample room so the
+        // JSON is never truncated (truncation reads as a schema mismatch).
+        maxOutputTokens: 32000,
         output: Output.object({
           schema: z.object({ modules: z.array(APlusGeneratedModuleSchema) }),
           name: 'a_plus_package_modules',
@@ -599,6 +607,65 @@ async function generateModulesParallel(
   );
   results.sort((a, b) => a.order - b.order);
   return { results, failures };
+}
+
+/**
+ * The brand-header module renders as a HERO only when it has a background slot
+ * (an ambient lifestyle backdrop behind the logo). The prompt asks for one, but
+ * if the model omits it we inject a default so the header never degrades to the
+ * plain band. The slot's image is filled by the downstream image-generate step.
+ */
+function ensureLogoBackdrop(
+  modules: z.infer<typeof APlusGeneratedModuleSchema>[]
+): void {
+  for (const module of modules) {
+    if (module.type === 'company-logo' && !module.background) {
+      module.background = {
+        role: 'brand-backdrop',
+        size: '1792x1024',
+        alt: 'Ambient brand lifestyle backdrop',
+        brief:
+          'An ambient, on-brand lifestyle environment appropriate to THIS product’s category and real-world use (the setting where it is naturally used or displayed — not any fixed theme), softly out of focus with gentle bokeh, layered depth and refined premium natural light. Compose with the main subject toward ONE side and clean, low-detail negative space on the OPPOSITE side so overlaid text stays legible. No product hero front-and-centre, no people staring at camera, no text or logos.',
+      };
+    }
+  }
+}
+
+/**
+ * Append a brand FOOTER — a centered closing brand band (`company-logo` with
+ * placement 'footer') — so the page has a clear bookend. Reuses the opening
+ * logo module's logo + tagline when present; idempotent and capped so we never
+ * exceed a sane module count. Product-agnostic.
+ */
+function ensureBrandFooter(
+  modules: z.infer<typeof APlusGeneratedModuleSchema>[]
+): void {
+  if (!modules.length || modules.length >= 7) return;
+  const last = modules[modules.length - 1];
+  if (last.type === 'company-logo' && last.placement === 'footer') return;
+  const header = modules.find((m) => m.type === 'company-logo');
+  const logo = header?.logo ?? {
+    role: 'logo',
+    brief: 'Brand logo (seller-supplied, never generated).',
+    size: '1024x1024' as const,
+    alt: 'Brand logo',
+  };
+  modules.push({
+    order: modules.length + 1,
+    type: 'company-logo',
+    amazonModuleType: 'STANDARD_COMPANY_LOGO',
+    title: 'Brand footer',
+    placement: 'footer',
+    logo,
+    tagline: header?.tagline,
+    background: {
+      role: 'footer-backdrop',
+      size: '1792x1024',
+      alt: 'Ambient brand backdrop',
+      brief:
+        'A dark, moody, on-brand ambient backdrop suited to THIS product’s category (the world it lives in — not any fixed theme), softly out of focus with gentle depth and warm low light, uncluttered. No product hero front-and-centre, no people staring at camera, no text or logos.',
+    },
+  });
 }
 
 export async function POST(request: Request) {
@@ -793,6 +860,10 @@ export async function POST(request: Request) {
           });
 
         moduleResults.sort((a, b) => a.order - b.order);
+        // Brand header renders as a hero only with a backdrop — guarantee one.
+        ensureLogoBackdrop(moduleResults);
+        // Close the page with a brand footer band (bookend).
+        ensureBrandFooter(moduleResults);
         const modulesMs = Date.now() - tModules;
         console.log(
           `[a-plus-generate] package modules: ${(modulesMs / 1000).toFixed(

--- a/apps/web/src/app/api/a-plus/image-generate/route.ts
+++ b/apps/web/src/app/api/a-plus/image-generate/route.ts
@@ -53,9 +53,13 @@ export async function POST(request: Request) {
     return Response.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  let body: { prompt?: unknown; size?: unknown };
+  let body: { prompt?: unknown; size?: unknown; quality?: unknown };
   try {
-    body = (await request.json()) as { prompt?: unknown; size?: unknown };
+    body = (await request.json()) as {
+      prompt?: unknown;
+      size?: unknown;
+      quality?: unknown;
+    };
   } catch {
     return Response.json({ error: 'Invalid request body.' }, { status: 400 });
   }
@@ -66,6 +70,15 @@ export async function POST(request: Request) {
       { status: 400 }
     );
   }
+
+  // Optional cost/quality tier — 'low' for cheap drafts. Invalid values fall
+  // through to the provider/env default (no error).
+  const quality =
+    body.quality === 'low' ||
+    body.quality === 'medium' ||
+    body.quality === 'high'
+      ? body.quality
+      : undefined;
 
   const provider = createAIProvider();
 
@@ -88,6 +101,7 @@ export async function POST(request: Request) {
     const results = await imageGenerator.generate({
       prompt: prepareImagePrompt(body.prompt),
       size,
+      quality,
     });
     const first = results[0];
     if (!first?.url) {

--- a/apps/web/src/app/api/a-plus/image-generate/route.ts
+++ b/apps/web/src/app/api/a-plus/image-generate/route.ts
@@ -43,7 +43,11 @@ function prepareImagePrompt(prompt: string): string {
   return [
     prompt,
     '',
-    'Important image rule: do not render brand names, brand badges, logos, brand lockups, watermarks, product labels with brand names, or readable brand marks anywhere in the image. Leave any brand/logo placement as an empty logo-safe area for later editing.',
+    // Hard realism override — enforced on EVERY image regardless of the brief,
+    // because conceptual cell labels (e.g. "Cross-Section Proof", "Insulation
+    // Engineering") otherwise push the model toward unrealistic diagram/CGI art.
+    'Important image rule: render a realistic, natural-light PHOTOGRAPH of the real physical product in a believable real-world setting. Absolutely NO cutaways, cross-sections, exploded or see-through/x-ray views, technical or engineering diagrams, schematics, blueprints, infographics, heat-maps, arrows/annotations, 3D or CGI renders, or abstract concept art. If the description implies an internal or technical detail, instead show the real product in a natural context that implies it (e.g. a hand holding it, a tidy stack on a counter) — never a depiction OF the concept.',
+    'Important image rule: do not render brand names, brand badges, logos, brand lockups, watermarks, product labels with brand names, readable brand marks, or any other text, callouts, or numbers anywhere in the image. Leave any brand/logo placement as an empty logo-safe area for later editing.',
   ].join('\n');
 }
 

--- a/apps/web/src/app/api/a-plus/module-image/route.ts
+++ b/apps/web/src/app/api/a-plus/module-image/route.ts
@@ -16,6 +16,7 @@ import {
 } from '@farvisionllc/models';
 import { auth0 } from '../../../../lib/auth0';
 import { createAssetS3Client, getAsset } from '../../../../lib/media-assets';
+import { SAMPLE_GALLERY } from './sample-gallery';
 import {
   APLUS_CANVAS_WIDTH,
   APLUS_MOBILE_CANVAS_WIDTH,
@@ -86,9 +87,10 @@ function estimateHeight(
   const w = mobile ? APLUS_MOBILE_CANVAS_WIDTH : APLUS_CANVAS_WIDTH;
   switch (module.type) {
     case 'company-logo':
-      // Brand hero with an ambient backdrop, else the tinted header band.
-      if (module.background) return mobile ? 320 : 420;
-      return (module.tagline ? (mobile ? 60 : 70) : 0) + (mobile ? 210 : 262);
+      if (module.placement === 'footer') return mobile ? 240 : 300;
+      // Brand hero with an ambient backdrop, else the framed brand band.
+      if (module.background) return mobile ? 420 : 480;
+      return (module.tagline ? (mobile ? 56 : 60) : 0) + (mobile ? 300 : 400);
     case 'image-text-overlay': {
       // Full-bleed overlay hero: content-driven, with a tall minimum.
       const pad = mobile ? 64 : 128;
@@ -176,13 +178,14 @@ function estimateHeight(
     case 'comparison-table': {
       const title = 76;
       const rows = module.rows.length;
+      // Cards carry a ribbon (26) + accent header (~54) + ~44px rows + padding.
       if (mobile) {
-        let h = title + 10;
+        let h = title + 12;
         for (let i = 0; i < module.products.length; i++)
-          h += 18 + 26 + 12 + rows * 30 + 18 + 10;
+          h += 26 + 54 + rows * 44 + 16 + 12;
         return h + 24;
       }
-      return title + 14 + 18 + 26 + 12 + rows * 30 + 18 + 30;
+      return title + 18 + 26 + 54 + rows * 44 + 16 + 34;
     }
     case 'tech-specs': {
       const title = 92;
@@ -206,6 +209,9 @@ function estimateHeight(
     case 'dual-use-split':
       // Two panels: side-by-side on desktop, stacked on mobile.
       return mobile ? 300 * module.panels.length : 380;
+    case 'icon-row':
+      // Title + a row of icon/label cells (stacked on mobile).
+      return mobile ? 76 + module.items.length * 64 + 24 : 76 + 16 + 122 + 28;
     default:
       return mobile ? 640 : 520;
   }
@@ -303,10 +309,16 @@ async function inlineThemeLogo(
         .png()
         .toBuffer();
       theme.logoUrl = `data:image/png;base64,${png.toString('base64')}`;
+      const meta = await sharp(png).metadata();
+      if (meta.width && meta.height)
+        theme.logoAspect = meta.width / meta.height;
     } else {
       theme.logoUrl = `data:${asset.mimeType};base64,${buffer.toString(
         'base64'
       )}`;
+      const meta = await sharp(buffer).metadata();
+      if (meta.width && meta.height)
+        theme.logoAspect = meta.width / meta.height;
     }
   } catch {
     theme.logoUrl = undefined;
@@ -365,32 +377,65 @@ function renderModule(
   });
 }
 
-const SAMPLE_MODULE: APlusGeneratedModule = {
-  order: 1,
-  amazonModuleType: 'STANDARD_THREE_IMAGE_TEXT',
-  title: 'Built for comfort & convenience',
-  type: 'three-image-text',
-  columns: [
-    {
-      image: { role: 'c1', brief: '', size: '1024x1024', alt: 'a' },
-      headline: 'Ripple wall insulation',
-      body: 'Keeps drinks hot while protecting your hands — no sleeve required.',
-    },
-    {
-      image: { role: 'c2', brief: '', size: '1024x1024', alt: 'b' },
-      headline: 'Secure lid',
-      body: 'Snap-fit lid helps prevent spills and keeps drinks warm on the go.',
-    },
-    {
-      image: { role: 'c3', brief: '', size: '1024x1024', alt: 'c' },
-      headline: 'Food-grade interior',
-      body: 'Smooth interior lining helps prevent leaks and preserves taste.',
-    },
-  ],
-};
+const SAMPLE_STYLES = ['editorial', 'modern', 'bold', 'minimal'] as const;
+
+/** Dev-only: rasterize a sample wordmark so the logo header is reviewable. */
+async function sampleLogoDataUrl(): Promise<string> {
+  const svg = Buffer.from(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="420" height="300" viewBox="0 0 420 300">
+       <g fill="none" stroke="#9C6B3F" stroke-width="9" stroke-linecap="round">
+         <path d="M150 130 h110 a28 28 0 0 1 0 56 h-10"/>
+         <path d="M150 130 v52 a38 38 0 0 0 38 38 h34 a38 38 0 0 0 38-38 v-52 z"/>
+         <path d="M185 108 c0-14 18-14 18-28M213 108 c0-14 18-14 18-28"/>
+       </g>
+       <text x="210" y="252" font-family="Georgia, serif" font-size="42" fill="#2A2018" text-anchor="middle">Filtered Blend</text>
+       <text x="210" y="282" font-family="system-ui, sans-serif" font-size="16" fill="#9C6B3F" letter-spacing="3" text-anchor="middle">PASSIONATE COFFEE</text>
+     </svg>`
+  );
+  const png = await sharp(svg, { density: 384 })
+    .resize({ height: 300, fit: 'inside' })
+    .png()
+    .toBuffer();
+  return `data:image/png;base64,${png.toString('base64')}`;
+}
+
+/**
+ * Dev-only ambient backdrop for previewing the hero. Uses a real photo when
+ * APLUS_SAMPLE_BACKDROP (or the default dev path) points to one, else falls back
+ * to a synthetic warm bokeh so the harness works with no assets.
+ */
+async function sampleBackdropDataUrl(): Promise<string> {
+  const path =
+    process.env['APLUS_SAMPLE_BACKDROP'] || '/tmp/aplus/img/coffee_sm.jpg';
+  try {
+    const { readFile } = await import('node:fs/promises');
+    const bytes = await readFile(path);
+    return `data:image/jpeg;base64,${bytes.toString('base64')}`;
+  } catch {
+    // fall through to the synthetic backdrop
+  }
+  const svg = Buffer.from(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="700" viewBox="0 0 1200 700">
+       <defs>
+         <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+           <stop offset="0" stop-color="#5b3d27"/>
+           <stop offset="1" stop-color="#24180f"/>
+         </linearGradient>
+       </defs>
+       <rect width="1200" height="700" fill="url(#g)"/>
+       <circle cx="250" cy="520" r="200" fill="#caa06a" opacity="0.55"/>
+       <circle cx="980" cy="180" r="240" fill="#3a2616" opacity="0.7"/>
+       <circle cx="720" cy="600" r="170" fill="#e6c08a" opacity="0.4"/>
+       <circle cx="520" cy="120" r="130" fill="#8a5a34" opacity="0.5"/>
+     </svg>`
+  );
+  const png = await sharp(svg).blur(38).png().toBuffer();
+  return `data:image/png;base64,${png.toString('base64')}`;
+}
 
 export async function GET(request: Request) {
-  // Dev-only sample render for verification (no auth, no S3).
+  // Dev-only design preview (no auth, no S3): renders any sample module/style.
+  //   /api/a-plus/module-image?sample=1&module=<kind>&style=<preset>&viewport=<vp>
   const url = new URL(request.url);
   if (
     url.searchParams.get('sample') === '1' &&
@@ -398,7 +443,65 @@ export async function GET(request: Request) {
   ) {
     const viewport =
       url.searchParams.get('viewport') === 'mobile' ? 'mobile' : 'desktop';
-    return renderModule(SAMPLE_MODULE, brandThemeFrom(null), viewport);
+    const styleParam = url.searchParams.get('style') ?? 'editorial';
+    const style = (SAMPLE_STYLES as readonly string[]).includes(styleParam)
+      ? (styleParam as (typeof SAMPLE_STYLES)[number])
+      : 'editorial';
+    const moduleKey = url.searchParams.get('module') ?? 'three-image-text';
+    const sampleModule =
+      SAMPLE_GALLERY[moduleKey] ?? SAMPLE_GALLERY['three-image-text'];
+    const theme = brandThemeFrom({ brandName: 'Filtered Blend' }, style);
+    let mod = sampleModule;
+    if (mod.type === 'company-logo') {
+      theme.logoUrl = await sampleLogoDataUrl();
+      theme.logoAspect = 420 / 300; // matches the sample wordmark viewBox
+      // The hero treatment is normally AI-chosen per product (module.heroVariant);
+      // ?hero= and ?corner= let the harness preview each choice.
+      const heroParam = url.searchParams.get('hero');
+      const heroVariant =
+        heroParam === 'plate' ||
+        heroParam === 'glass' ||
+        heroParam === 'split' ||
+        heroParam === 'overlay'
+          ? heroParam
+          : undefined;
+      const cornerParam = url.searchParams.get('corner');
+      const logoCorner =
+        cornerParam === 'bottom-left' || cornerParam === 'bottom-right'
+          ? cornerParam
+          : undefined;
+      // ?headline= / ?tagline= override the sample copy so ANY product can be
+      // previewed (the feature is product-agnostic; the gallery is just one).
+      // ?bg=1 attaches an ambient backdrop so the hero is reviewable without
+      // running real image generation.
+      const hl = url.searchParams.get('headline');
+      const tl = url.searchParams.get('tagline');
+      const bg =
+        url.searchParams.get('bg') === '1'
+          ? await sampleBackdropDataUrl()
+          : undefined;
+      const footer = url.searchParams.get('placement') === 'footer';
+      mod = {
+        ...mod,
+        ...(footer ? { placement: 'footer' as const } : {}),
+        ...(heroVariant ? { heroVariant } : {}),
+        ...(logoCorner ? { logoCorner } : {}),
+        ...(hl !== null ? { headline: hl } : {}),
+        ...(tl !== null ? { tagline: tl } : {}),
+        ...(bg
+          ? {
+              background: {
+                role: 'backdrop',
+                brief: 'ambient brand backdrop',
+                size: '1792x1024' as const,
+                alt: 'Ambient lifestyle backdrop',
+                image: { url: bg, alt: 'Ambient lifestyle backdrop' },
+              },
+            }
+          : {}),
+      };
+    }
+    return renderModule(mod, theme, viewport);
   }
   return Response.json({ error: 'Use POST.' }, { status: 405 });
 }

--- a/apps/web/src/app/api/a-plus/module-image/sample-gallery.ts
+++ b/apps/web/src/app/api/a-plus/module-image/sample-gallery.ts
@@ -1,0 +1,181 @@
+import type {
+  APlusGeneratedModule,
+  APlusGeneratedModuleKind,
+  APlusImageSlot,
+} from '@farvisionllc/models';
+
+/**
+ * Dev-only sample modules for the `?sample=1&module=<kind>` design preview.
+ * Realistic "Filtered Blend" coffee-cup copy so renders read like real A+
+ * content. Image slots intentionally have no resolved `image` so they show the
+ * placeholder — this harness is for iterating on layout/typography/colour, not
+ * imagery. Never imported by production code paths.
+ */
+
+const slot = (
+  role: string,
+  alt: string,
+  size: APlusImageSlot['size'] = '1792x1024'
+): APlusImageSlot => ({ role, brief: 'sample brief', size, alt });
+
+const base = <T extends APlusGeneratedModuleKind>(
+  type: T,
+  amazonModuleType: string,
+  title: string
+) => ({ order: 1 as const, type, amazonModuleType, title });
+
+export const SAMPLE_GALLERY: Record<string, APlusGeneratedModule> = {
+  'company-logo': {
+    ...base('company-logo', 'STANDARD_COMPANY_LOGO', 'Brand logo'),
+    logo: slot('logo', 'Filtered Blend logo', '1024x1024'),
+    headline: 'Filtered Blend Ripple Wall Coffee Cups',
+    tagline: 'Comfortable grip · heat resistant · built for coffee to-go.',
+  },
+  'image-text-overlay': {
+    ...base('image-text-overlay', 'STANDARD_IMAGE_TEXT_OVERLAY', 'Hero'),
+    image: slot('hero', 'Barista pouring espresso into a kraft ripple cup'),
+    headline: 'Premium 8 oz cups for coffee lovers',
+    body: 'Double-wall ripple insulation keeps drinks hot and hands comfortable — no sleeve required.',
+    overlayPosition: 'left',
+    badge: '50-PACK',
+  },
+  'image-and-text': {
+    ...base('image-and-text', 'STANDARD_SINGLE_SIDE_IMAGE', 'Feature'),
+    image: slot('feature', 'Close-up of ripple wall insulation', '1024x1024'),
+    imagePosition: 'right',
+    headline: 'Engineered for everyday comfort',
+    body: 'Each cup is built from food-grade kraft with a ripple wall that traps heat and protects your hands.',
+    bullets: [
+      'Ripple wall insulation retains heat',
+      'Sturdy snap-fit lid resists spills',
+      'Sustainable, food-grade kraft exterior',
+    ],
+    badge: '8 OZ',
+  },
+  'three-image-text': {
+    ...base(
+      'three-image-text',
+      'STANDARD_THREE_IMAGE_TEXT',
+      'Built for comfort & convenience'
+    ),
+    columns: [
+      {
+        image: slot('c1', 'Ripple wall', '1024x1024'),
+        headline: 'Ripple wall insulation',
+        body: 'Keeps drinks hot while protecting your hands — no sleeve required.',
+      },
+      {
+        image: slot('c2', 'Secure lid', '1024x1024'),
+        headline: 'Secure lid',
+        body: 'Snap-fit lid helps prevent spills and keeps drinks warm on the go.',
+      },
+      {
+        image: slot('c3', 'Food-grade interior', '1024x1024'),
+        headline: 'Food-grade interior',
+        body: 'Smooth interior lining helps prevent leaks and preserves taste.',
+      },
+    ],
+  },
+  'four-image-text-quadrant': {
+    ...base(
+      'four-image-text-quadrant',
+      'STANDARD_FOUR_IMAGE_TEXT_QUADRANT',
+      'Why specialty cafés choose us'
+    ),
+    quadrants: [
+      {
+        image: slot('q1', 'Hot drinks', '1024x1024'),
+        headline: 'Hot or cold',
+        body: 'Holds espresso, drip, and iced pours alike.',
+      },
+      {
+        image: slot('q2', 'Ripple grip', '1024x1024'),
+        headline: 'Comfort grip',
+        body: 'Ripple wall stays cool to the touch.',
+      },
+      {
+        image: slot('q3', 'Matching lids', '1024x1024'),
+        headline: 'Matching lids',
+        body: 'Snap-fit lids included in every pack.',
+      },
+      {
+        image: slot('q4', 'Kraft finish', '1024x1024'),
+        headline: 'Kraft finish',
+        body: 'Clean, professional presentation.',
+      },
+    ],
+  },
+  'comparison-table': {
+    ...base(
+      'comparison-table',
+      'STANDARD_COMPARISON_TABLE',
+      'Why choose ripple wall cups'
+    ),
+    products: [
+      {
+        title: 'Ripple Wall Cups',
+        image: slot('p1', 'Ripple wall cup', '1024x1024'),
+        highlight: true,
+      },
+      { title: 'Standard Cups', image: slot('p2', 'Plain cup', '1024x1024') },
+    ],
+    rows: [
+      { label: 'Comfortable to hold', values: ['Yes', 'No'] },
+      { label: 'No sleeve needed', values: ['Yes', 'No'] },
+      { label: 'Ripple insulation', values: ['Yes', 'No'] },
+      { label: 'Matching lids', values: ['Included', 'Sold separately'] },
+    ],
+  },
+  'tech-specs': {
+    ...base('tech-specs', 'STANDARD_TECH_SPECS', 'Technical specifications'),
+    headline: 'Everything you need to know',
+    rows: [
+      { label: 'Capacity', value: '8 fl oz (237 ml)' },
+      { label: 'Material', value: 'Double-wall food-grade kraft paper' },
+      { label: 'Lid', value: 'Snap-fit, included' },
+      { label: 'Pack size', value: '50 cups with lids' },
+      { label: 'Use', value: 'Hot and cold beverages' },
+    ],
+  },
+  'text-only': {
+    ...base(
+      'text-only',
+      'STANDARD_PRODUCT_DESCRIPTION',
+      'About Filtered Blend'
+    ),
+    headline: 'Crafted for the ritual of coffee',
+    body: 'Filtered Blend cups are designed to honor the everyday ritual of coffee — whether you are serving specialty espresso to guests or enjoying a quiet morning at home. The ripple wall insulation keeps drinks at the perfect temperature while the sustainable kraft exterior reflects the care you put into every cup.',
+    bullets: [
+      'Double-wall ripple insulation',
+      'Sustainable food-grade kraft',
+      'Matching snap-fit lids included',
+    ],
+  },
+  'icon-row': {
+    ...base('icon-row', 'STANDARD_ICON_ROW', 'Perfect for any occasion'),
+    items: [
+      { icon: 'coffee', label: 'Coffee' },
+      { icon: 'droplet', label: 'Tea' },
+      { icon: 'building', label: 'Offices' },
+      { icon: 'users', label: 'Events' },
+      { icon: 'home', label: 'At home' },
+    ],
+  },
+  'dual-use-split': {
+    ...base('dual-use-split', 'STANDARD_DUAL_USE_SPLIT', 'Hot or cold'),
+    panels: [
+      {
+        image: slot('hot', 'Hot espresso pour'),
+        label: 'Hot',
+        caption: 'Ripple insulation keeps espresso and drip hot for longer.',
+      },
+      {
+        image: slot('cold', 'Iced coffee'),
+        label: 'Cold',
+        caption: 'Double walls cut condensation on iced pours.',
+      },
+    ],
+  },
+};
+
+export const SAMPLE_GALLERY_KINDS = Object.keys(SAMPLE_GALLERY);

--- a/apps/web/src/lib/a-plus-asset-cleanup.ts
+++ b/apps/web/src/lib/a-plus-asset-cleanup.ts
@@ -1,0 +1,140 @@
+import { deleteAsset, getAsset } from './media-assets';
+import {
+  listAllAPlusDraftDocs,
+  listBrandGuides,
+  type APlusDraft,
+} from './a-plus-drafts';
+
+/**
+ * Reference-aware garbage collection for A+ generated images.
+ *
+ * Assets are deduped by content hash and can be shared across drafts/brand
+ * guides, so we never delete by age — only when nothing references an asset.
+ * And we only ever auto-delete *generated* images (filename `generated-*`);
+ * user uploads are never removed automatically.
+ *
+ * Asset ids follow `asset_<uuid>` (see media-assets.createAssetId). Rather than
+ * walk every possible nesting in the opaque draft payload, we scan the
+ * stringified document for those ids — robust to wherever a slot/library/logo
+ * happens to store them.
+ */
+const ASSET_ID_RE =
+  /asset_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/g;
+
+/** All `asset_*` ids referenced anywhere inside an arbitrary JSON value. */
+export function collectAssetIds(value: unknown): Set<string> {
+  const ids = new Set<string>();
+  if (value == null) return ids;
+  const json = typeof value === 'string' ? value : safeStringify(value);
+  for (const match of json.matchAll(ASSET_ID_RE)) ids.add(match[0]);
+  return ids;
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function draftAssetIds(
+  draft: Pick<APlusDraft, 'payload' | 'packageJson'>
+): Set<string> {
+  const ids = collectAssetIds(draft.payload);
+  for (const id of collectAssetIds(draft.packageJson)) ids.add(id);
+  return ids;
+}
+
+/**
+ * The set of asset ids still referenced by any of the user's drafts (optionally
+ * excluding one draft) plus brand-guide logos.
+ */
+async function referencedAssetIds(
+  userId: string,
+  excludeDraftId?: string
+): Promise<Set<string>> {
+  const [drafts, guides] = await Promise.all([
+    listAllAPlusDraftDocs(userId),
+    listBrandGuides(userId),
+  ]);
+
+  const refs = new Set<string>();
+  for (const draft of drafts) {
+    if (excludeDraftId && draft.draftId === excludeDraftId) continue;
+    for (const id of draftAssetIds(draft)) refs.add(id);
+  }
+  for (const guide of guides) {
+    if (guide.logoAsset?.assetId) refs.add(guide.logoAsset.assetId);
+  }
+  return refs;
+}
+
+/**
+ * Delete each candidate asset that (a) is a generated image, (b) belongs to the
+ * user, and (c) is referenced by nothing else. Returns the count deleted.
+ */
+async function gcGeneratedAssets(
+  userId: string,
+  candidateIds: Iterable<string>,
+  excludeDraftId?: string
+): Promise<number> {
+  const candidates = [...new Set(candidateIds)];
+  if (candidates.length === 0) return 0;
+
+  const referenced = await referencedAssetIds(userId, excludeDraftId);
+
+  let deleted = 0;
+  for (const assetId of candidates) {
+    if (referenced.has(assetId)) continue;
+    const asset = await getAsset(assetId);
+    if (!asset || asset.userId !== userId) continue;
+    // Safety bound: never auto-delete user uploads, only generated images.
+    if (!asset.originalFileName.startsWith('generated-')) continue;
+    if (await deleteAsset(assetId)) deleted++;
+  }
+  return deleted;
+}
+
+/**
+ * On draft save: delete generated images the *previous* version referenced that
+ * the *new* version no longer does (e.g. after a slot image was refreshed),
+ * provided nothing else still references them. No-op when nothing was dropped,
+ * so the common autosave path does zero extra DB work.
+ */
+export async function cleanupSupersededDraftAssets(params: {
+  userId: string;
+  draftId: string;
+  oldDraft: Pick<APlusDraft, 'payload' | 'packageJson'> | null;
+  newPayload: unknown;
+  newPackageJson: unknown;
+}): Promise<number> {
+  if (!params.oldDraft) return 0;
+
+  const oldIds = draftAssetIds(params.oldDraft);
+  const newIds = new Set<string>([
+    ...collectAssetIds(params.newPayload),
+    ...collectAssetIds(params.newPackageJson),
+  ]);
+
+  const dropped = [...oldIds].filter((id) => !newIds.has(id));
+  if (dropped.length === 0) return 0;
+
+  return gcGeneratedAssets(params.userId, dropped, params.draftId);
+}
+
+/**
+ * On draft delete: delete the generated images this draft referenced that no
+ * other draft/brand-guide references.
+ */
+export async function cleanupDeletedDraftAssets(params: {
+  userId: string;
+  draftId: string;
+  draft: Pick<APlusDraft, 'payload' | 'packageJson'>;
+}): Promise<number> {
+  return gcGeneratedAssets(
+    params.userId,
+    draftAssetIds(params.draft),
+    params.draftId
+  );
+}

--- a/apps/web/src/lib/a-plus-asset-cleanup.ts
+++ b/apps/web/src/lib/a-plus-asset-cleanup.ts
@@ -49,6 +49,13 @@ function draftAssetIds(
 /**
  * The set of asset ids still referenced by any of the user's drafts (optionally
  * excluding one draft) plus brand-guide logos.
+ *
+ * INVARIANT: A+ drafts (module slots) and brand-guide logos are the ONLY places
+ * generated A+ images are referenced. This is what makes age-free GC safe. If a
+ * new feature ever references these assets (a published/exported listing, a chat
+ * attachment, an ads creative, etc.), it MUST be added to this scan — otherwise
+ * cleanup will delete an in-use image. When that happens, prefer moving to real
+ * reference-counting on the asset doc over chasing every referencer here.
  */
 async function referencedAssetIds(
   userId: string,
@@ -91,7 +98,7 @@ async function gcGeneratedAssets(
     if (!asset || asset.userId !== userId) continue;
     // Safety bound: never auto-delete user uploads, only generated images.
     if (!asset.originalFileName.startsWith('generated-')) continue;
-    if (await deleteAsset(assetId)) deleted++;
+    if (await deleteAsset(assetId, userId)) deleted++;
   }
   return deleted;
 }

--- a/apps/web/src/lib/a-plus-drafts.ts
+++ b/apps/web/src/lib/a-plus-drafts.ts
@@ -105,6 +105,25 @@ export async function listAPlusDrafts(
   return result.rows;
 }
 
+/**
+ * Full draft documents (incl. `payload` + `packageJson`) for one user — used by
+ * asset cleanup to scan for which assets are still referenced. Heavier than
+ * {@link listAPlusDrafts}; call only when you need the whole payload.
+ */
+export async function listAllAPlusDraftDocs(
+  userId: string
+): Promise<APlusDraft[]> {
+  const result = await executeQuery<APlusDraft>(
+    SCOPE,
+    `SELECT RAW d
+     FROM \`${DRAFTS_COLLECTION}\` d
+     WHERE d.userId = $userId
+     AND d.\`deleted\` IS MISSING`,
+    { parameters: { userId } }
+  );
+  return result.rows;
+}
+
 export async function getAPlusDraft(params: {
   userId: string;
   draftId: string;

--- a/apps/web/src/lib/media-assets.ts
+++ b/apps/web/src/lib/media-assets.ts
@@ -176,10 +176,17 @@ export async function headAssetObject(asset: MediaAsset) {
  * Best-effort on S3: if the object delete fails we still remove the DB records
  * so the asset stops appearing/serving. Callers are responsible for ensuring
  * the asset is unreferenced before calling this — see a-plus-asset-cleanup.
+ *
+ * `userId` is required and enforced here (defense in depth): an asset is never
+ * deleted unless it belongs to the caller, so a future caller can't turn this
+ * into an IDOR delete by omitting the ownership check.
  */
-export async function deleteAsset(assetId: string): Promise<boolean> {
+export async function deleteAsset(
+  assetId: string,
+  userId: string
+): Promise<boolean> {
   const asset = await getAsset(assetId);
-  if (!asset) return false;
+  if (!asset || asset.userId !== userId) return false;
 
   try {
     await createAssetS3Client().send(

--- a/apps/web/src/lib/media-assets.ts
+++ b/apps/web/src/lib/media-assets.ts
@@ -1,6 +1,14 @@
 import crypto from 'node:crypto';
-import { HeadObjectCommand, S3Client } from '@aws-sdk/client-s3';
-import { getDocument, upsertDocument } from '@amz-spapi/couchbase-utils';
+import {
+  DeleteObjectCommand,
+  HeadObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import {
+  deleteDocument,
+  getDocument,
+  upsertDocument,
+} from '@amz-spapi/couchbase-utils';
 
 export type MediaAssetFeature = 'a-plus' | 'ads' | 'listings' | 'shared';
 
@@ -158,4 +166,43 @@ export async function headAssetObject(asset: MediaAsset) {
       Key: asset.storage.key,
     })
   );
+}
+
+/**
+ * Permanently delete an asset: its S3 object, its Couchbase doc, and its
+ * sha256 hash pointer (only when the pointer still points at this asset, so a
+ * later asset that re-deduped onto the same hash isn't orphaned).
+ *
+ * Best-effort on S3: if the object delete fails we still remove the DB records
+ * so the asset stops appearing/serving. Callers are responsible for ensuring
+ * the asset is unreferenced before calling this — see a-plus-asset-cleanup.
+ */
+export async function deleteAsset(assetId: string): Promise<boolean> {
+  const asset = await getAsset(assetId);
+  if (!asset) return false;
+
+  try {
+    await createAssetS3Client().send(
+      new DeleteObjectCommand({
+        Bucket: asset.storage.bucket,
+        Key: asset.storage.key,
+      })
+    );
+  } catch {
+    // Object may already be gone; continue removing the DB records.
+  }
+
+  await deleteDocument(SCOPE, ASSETS_COLLECTION, assetDocKey(assetId));
+
+  const pointerKey = hashDocKey(asset.userId, asset.hashes.sha256);
+  const pointer = await getDocument<MediaAssetHashPointer>(
+    SCOPE,
+    HASHES_COLLECTION,
+    pointerKey
+  );
+  if (pointer?.assetId === assetId) {
+    await deleteDocument(SCOPE, HASHES_COLLECTION, pointerKey);
+  }
+
+  return true;
 }

--- a/libs/ai-provider/src/create-provider.ts
+++ b/libs/ai-provider/src/create-provider.ts
@@ -101,6 +101,9 @@ export function createAIProvider(config: AIProviderConfig = {}): AIProvider {
         IMAGE_MODELS[variant] ?? IMAGE_MODELS[DEFAULT_IMAGE_VARIANT];
       return {
         async generate(params: Parameters<ImageGenerator['generate']>[0]) {
+          // Per-request quality wins over the model/env default; only the
+          // size-based backend (gpt-image-1) honors it — others ignore it.
+          const quality = params.quality ?? model.quality;
           const { image } = await generateImage({
             model: model.slug,
             prompt: params.prompt,
@@ -111,8 +114,8 @@ export function createAIProvider(config: AIProviderConfig = {}): AIProvider {
                     params.size
                   ) as `${number}:${number}`,
                 }),
-            ...(model.quality
-              ? { providerOptions: { openai: { quality: model.quality } } }
+            ...(quality && model.sizing === 'size'
+              ? { providerOptions: { openai: { quality } } }
               : {}),
           });
           return [

--- a/libs/ai-provider/src/types.ts
+++ b/libs/ai-provider/src/types.ts
@@ -20,6 +20,12 @@ export interface ImageGenerator {
     prompt: string;
     size?: '1024x1024' | '1792x1024' | '1024x1792';
     n?: number;
+    /**
+     * Cost/quality tier — 'low' for cheap drafts, 'high' for finals. Only
+     * applied by backends that support it (e.g. gpt-image-1); ignored otherwise.
+     * Falls back to the provider/env default when omitted.
+     */
+    quality?: 'low' | 'medium' | 'high';
   }): Promise<
     {
       url: string;

--- a/packages/models/src/lib/aplus.ts
+++ b/packages/models/src/lib/aplus.ts
@@ -120,10 +120,23 @@ const companyLogoModule = z.object({
   ...moduleBase,
   type: z.literal('company-logo'),
   logo: APlusImageSlotSchema,
-  /** Short brand promise shown under the logo in the header band. */
+  /** Brand/product headline shown over the hero backdrop (e.g. brand + product). */
+  headline: z.string().max(120).optional(),
+  /** Short brand promise / benefit subhead shown under the headline. */
   tagline: z.string().max(120).optional(),
   /** Ambient brand backdrop photo behind the logo (NOT the logo itself). */
   background: APlusImageSlotSchema.optional(),
+  /** 'header' = opening brand hero (default); 'footer' = centered closing band. */
+  placement: z.enum(['header', 'footer']).optional(),
+  /**
+   * AI-chosen hero treatment so pages don't all look identical:
+   * 'overlay' = text on photo, logo in a corner bar; 'split' = photo beside a
+   * brand panel; 'plate'/'glass' = logo card centered over the photo. Free
+   * string so an unexpected value falls back to a default instead of failing.
+   */
+  heroVariant: z.string().optional(),
+  /** Corner for the overlay logo bar (AI-chosen): 'bottom-left'|'bottom-right'. */
+  logoCorner: z.string().optional(),
 });
 const imageHeaderWithTextModule = z.object({
   ...moduleBase,
@@ -242,8 +255,49 @@ const dualUseSplitModule = z.object({
     .length(2),
 });
 
+/** Generic, brand-agnostic icon set for the icon-row benefit strip. */
+export const ICON_ROW_ICONS = [
+  'coffee',
+  'leaf',
+  'shield',
+  'zap',
+  'heart',
+  'star',
+  'package',
+  'home',
+  'gift',
+  'sparkles',
+  'building',
+  'users',
+  'check',
+  'clock',
+  'droplet',
+  'thermometer',
+] as const;
+export type IconRowIcon = (typeof ICON_ROW_ICONS)[number];
+
+const iconRowModule = z.object({
+  ...moduleBase,
+  type: z.literal('icon-row'),
+  /**
+   * 2–6 icon + short-label highlights (e.g. use cases or key benefits). `icon`
+   * is a free string (the model picks an intuitive name); the renderer maps it
+   * to the closest supported glyph, so an unknown name never breaks generation.
+   */
+  items: z
+    .array(
+      z.object({
+        icon: z.string().max(40),
+        label: z.string().max(40),
+      })
+    )
+    .min(2)
+    .max(6),
+});
+
 export const APlusGeneratedModuleSchema = z.discriminatedUnion('type', [
   companyLogoModule,
+  iconRowModule,
   imageHeaderWithTextModule,
   imageTextOverlayModule,
   singleImageTextModule,
@@ -271,6 +325,7 @@ export const BASIC_A_PLUS_MODULE_TYPES = [
   'tech-specs',
   'text-only',
   'dual-use-split',
+  'icon-row',
 ] as const satisfies readonly APlusGeneratedModuleKind[];
 
 /** Per-kind schema, so callers can constrain generation to one module type. */
@@ -286,6 +341,7 @@ export const APLUS_GENERATED_MODULE_SCHEMA_BY_KIND = {
   'tech-specs': techSpecsModule,
   'text-only': textOnlyModule,
   'dual-use-split': dualUseSplitModule,
+  'icon-row': iconRowModule,
 } as const satisfies Record<APlusGeneratedModuleKind, z.ZodTypeAny>;
 
 export function generatedModuleSchemaForKind(
@@ -323,6 +379,9 @@ export const AMAZON_MODULE_TYPE_TO_KIND: Record<
   // A two-panel scenario split (e.g. Hot vs Cold). Exports as one image; the
   // seller uploads it into a standard image module in Seller Central.
   STANDARD_DUAL_USE_SPLIT: 'dual-use-split',
+  // No native Amazon icon-row module — the strip bakes into one image the
+  // seller drops into a standard image module.
+  STANDARD_ICON_ROW: 'icon-row',
 };
 
 export function amazonModuleTypeToKind(
@@ -410,6 +469,7 @@ export const RENDERABLE_AMAZON_MODULE_TYPES = [
   'STANDARD_TECH_SPECS',
   'STANDARD_PRODUCT_DESCRIPTION',
   'STANDARD_DUAL_USE_SPLIT',
+  'STANDARD_ICON_ROW',
 ] as const satisfies readonly (keyof typeof AMAZON_MODULE_TYPE_TO_KIND)[];
 export type RenderableAmazonModuleType =
   (typeof RENDERABLE_AMAZON_MODULE_TYPES)[number];
@@ -436,6 +496,7 @@ export const SELLER_CENTRAL_MODULE_NAMES: Record<string, string> = {
   STANDARD_TEXT: 'Standard Text',
   STANDARD_THREE_IMAGE_TEXT: 'Standard Three Image & Text',
   STANDARD_DUAL_USE_SPLIT: 'Standard Image (two-scenario split)',
+  STANDARD_ICON_ROW: 'Standard Image (icon highlights strip)',
 };
 
 /** Seller Central A+ module picker name for a given module type. */
@@ -469,6 +530,7 @@ export function moduleImageSlots(
       );
     case 'tech-specs':
     case 'text-only':
+    case 'icon-row':
       return [];
     default:
       return [];
@@ -540,6 +602,11 @@ export function moduleTextFields(
       push('Body', module.body);
       module.bullets?.forEach((bullet, index) =>
         push(`Bullet ${index + 1}`, bullet)
+      );
+      break;
+    case 'icon-row':
+      module.items.forEach((item, index) =>
+        push(`Icon ${index + 1} label`, item.label)
       );
       break;
   }

--- a/tools/aplus-render.sh
+++ b/tools/aplus-render.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Dev-only A+ module design-preview renderer.
+#
+# Renders sample modules to PNG via the dev sample endpoint (no auth / no S3),
+# so the design system can be iterated on visually.
+#
+# Usage:
+#   tools/aplus-render.sh <module|all> [style] [viewport]
+#
+#   module   one of the gallery kinds, or "all"   (default: three-image-text)
+#   style    editorial | modern | bold | minimal  (default: editorial)
+#   viewport desktop | mobile                      (default: desktop)
+#
+# Env:
+#   APLUS_RENDER_BASE  dev server origin (default https://local.sellavant.com:9443)
+#   APLUS_RENDER_OUT   output dir        (default /tmp/aplus)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASE="${APLUS_RENDER_BASE:-https://local.sellavant.com:9443}"
+OUT="${APLUS_RENDER_OUT:-$SCRIPT_DIR/render-out}"
+mkdir -p "$OUT"
+
+MODULES=(company-logo image-text-overlay image-and-text three-image-text \
+  four-image-text-quadrant comparison-table tech-specs text-only dual-use-split)
+
+module="${1:-three-image-text}"
+style="${2:-editorial}"
+viewport="${3:-desktop}"
+
+render() {
+  local m="$1"
+  local f="$OUT/${m}-${style}-${viewport}.png"
+  local code
+  code=$(curl -sk -o "$f" -w '%{http_code}' \
+    "$BASE/api/a-plus/module-image?sample=1&module=${m}&style=${style}&viewport=${viewport}")
+  if [ "$code" = "200" ]; then
+    echo "$f"
+  else
+    echo "FAILED ($code): $m" >&2
+  fi
+}
+
+if [ "$module" = "all" ]; then
+  for m in "${MODULES[@]}"; do render "$m"; done
+else
+  render "$module"
+fi


### PR DESCRIPTION
## Summary
A batch of A+ Content Studio improvements spanning the renderer, the image/asset lifecycle, generation robustness, and cost controls.

## Highlights

**Asset lifecycle**
- Keep AI-generated images out of the Assets step (they live only in module slots); older drafts' generated entries filtered on load.
- Reference-aware GC (generated-only, never uploads): free a refreshed slot's prior image on draft **save** (undo-friendly) and a deleted draft's uniquely-owned images on delete.
- On-the-fly `?w=` thumbnails + full-res modal in the library.
- "Rebuild from sources" button: clears the notes brief and re-extracts all linked sources under the current rules.
- Multi-image drop fix: unique ids (no React-key collisions) + accept images by extension when MIME is empty.

**Generation quality & correctness**
- Photorealism guardrail at the image-model chokepoint (no cutaways/diagrams/CGI).
- Stop competitor attributes (e.g. a competitor's brown cups) and price from leaking into copy/imagery — clearer source labeling + subject-product-only rules in the shot bible, module rules, and strategy prompt.
- Price removed from extraction notes and never sent to the model (A+ never shows price).

**Model support & cost**
- Make package generation work with **OpenAI** generation models (e.g. GPT-5.4): set `strictJsonSchema: false` for OpenAI structured outputs (AI SDK v6 defaults it to true, which rejects our discriminated-union schema; Anthropic's tool-based path was lenient).
- Image cost controls: fix reload double-spend; add a draft/final quality toggle (gpt-image-1).

**Security hardening** (from a self-review pass)
- `deleteAsset` requires `userId` and enforces ownership (defense in depth).
- Thumbnail `?w=` snapped to fixed buckets + explicit `sharp` `limitInputPixels` cap.
- Documented the GC reference-scan invariant.

## Notes / verification
- `tsc` + `nx lint web` clean across all commits (lint warnings are pre-existing).
- The deletion/GC logic is reference-safe by construction (generated-only, scans all drafts) but was **not** runtime-tested against Couchbase; OpenAI generation and image paths were verified statically (docs/types), not executed live. Worth a manual smoke test after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)